### PR TITLE
Make pysquared able to be pulled into other repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ artifacts/
 coverage-reports/
 tools/
 venv
+build/
+pysquared.egg-info/
 **/*.mpy
 
 # libs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "pytest==8.3.2",
 ]
 
+[tool.setuptools]
+packages = ["pysquared"]
+
 [tool.ruff.format]
 # Use `\n` line endings for all files
 line-ending = "lf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,15 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["pysquared"]
-
+packages = [
+    "pysquared",
+    "pysquared.config",
+    "pysquared.hardware",
+    "pysquared.hardware.rfm9x",
+    "pysquared.nvm",
+    "pysquared.rtc",
+    "pysquared.usb"
+]
 [tool.ruff.format]
 # Use `\n` line endings for all files
 line-ending = "lf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "circuitpy-flight-software"
+name = "pysquared"
 version = "2.0.0"
 description = "Flight Software for the PROVES Kit"
 readme = "README.md"

--- a/pysquared/Big_Data.py
+++ b/pysquared/Big_Data.py
@@ -1,7 +1,8 @@
 import gc
 
 import lib.adafruit_tca9548a as adafruit_tca9548a  # I2C Multiplexer
-from pysquared.logger import Logger
+
+from .logger import Logger
 
 try:
     from typing import Union

--- a/pysquared/cdh.py
+++ b/pysquared/cdh.py
@@ -1,11 +1,11 @@
 import random
 import time
 
-from pysquared.config.config import Config
-from pysquared.hardware.rfm9x.manager import RFM9xManager
-from pysquared.hardware.rfm9x.modulation import RFM9xModulation
-from pysquared.logger import Logger
-from pysquared.pysquared import Satellite
+from .config.config import Config
+from .hardware.rfm9x.manager import RFM9xManager
+from .hardware.rfm9x.modulation import RFM9xModulation
+from .logger import Logger
+from .pysquared import Satellite
 
 try:
     from typing import Any, Union

--- a/pysquared/config/config.py
+++ b/pysquared/config/config.py
@@ -9,7 +9,7 @@ Attempting to follow the FPrime model.
 
 import json
 
-from pysquared.config.radio import RadioConfig
+from .radio import RadioConfig
 
 
 class Config:

--- a/pysquared/functions.py
+++ b/pysquared/functions.py
@@ -9,13 +9,13 @@ import gc
 import random
 import time
 
-from pysquared.config.config import Config
-from pysquared.hardware.rfm9x.manager import RFM9xManager
-from pysquared.logger import Logger
-from pysquared.packet_manager import PacketManager
-from pysquared.packet_sender import PacketSender
-from pysquared.pysquared import Satellite
-from pysquared.sleep_helper import SleepHelper
+from .config.config import Config
+from .hardware.rfm9x.manager import RFM9xManager
+from .logger import Logger
+from .packet_manager import PacketManager
+from .packet_sender import PacketSender
+from .pysquared import Satellite
+from .sleep_helper import SleepHelper
 
 try:
     from typing import List, OrderedDict, Union

--- a/pysquared/hardware/busio.py
+++ b/pysquared/hardware/busio.py
@@ -1,9 +1,9 @@
 from busio import SPI
 from microcontroller import Pin
 
-from pysquared.hardware.decorators import with_retries
-from pysquared.hardware.exception import HardwareInitializationError
-from pysquared.logger import Logger
+from ..logger import Logger
+from .decorators import with_retries
+from .exception import HardwareInitializationError
 
 try:
     from typing import Optional

--- a/pysquared/hardware/decorators.py
+++ b/pysquared/hardware/decorators.py
@@ -1,6 +1,6 @@
 import time
 
-from pysquared.hardware.exception import HardwareInitializationError
+from .exception import HardwareInitializationError
 
 
 def with_retries(max_attempts: int = 3, initial_delay: float = 1.0):

--- a/pysquared/hardware/digitalio.py
+++ b/pysquared/hardware/digitalio.py
@@ -1,9 +1,9 @@
 from digitalio import DigitalInOut, Direction
 from microcontroller import Pin
 
-from pysquared.hardware.decorators import with_retries
-from pysquared.hardware.exception import HardwareInitializationError
-from pysquared.logger import Logger
+from ..logger import Logger
+from .decorators import with_retries
+from .exception import HardwareInitializationError
 
 
 @with_retries(max_attempts=3, initial_delay=1)

--- a/pysquared/hardware/rfm9x/factory.py
+++ b/pysquared/hardware/rfm9x/factory.py
@@ -9,13 +9,13 @@ try:
     from lib.adafruit_rfm.rfm9xfsk import RFM9xFSK
 except ImportError:
     from mocks.circuitpython.adafruit_rfm.rfm9x import RFM9x  # type: ignore
-    from mocks.circuitpython.adafruit_rfm.rfm9xfsk import \
-        RFM9xFSK  # type: ignore
+    from mocks.circuitpython.adafruit_rfm.rfm9xfsk import RFM9xFSK  # type: ignore
 
 # Type hinting only
 try:
     from busio import SPI
     from digitalio import DigitalInOut
+
     from lib.adafruit_rfm.rfm_common import RFMSPI
 except ImportError:
     pass

--- a/pysquared/hardware/rfm9x/factory.py
+++ b/pysquared/hardware/rfm9x/factory.py
@@ -1,21 +1,21 @@
-from pysquared.config.radio import FSKConfig, LORAConfig, RadioConfig
-from pysquared.hardware.decorators import with_retries
-from pysquared.hardware.exception import HardwareInitializationError
-from pysquared.hardware.rfm9x.modulation import RFM9xModulation
-from pysquared.logger import Logger
+from ...config.radio import FSKConfig, LORAConfig, RadioConfig
+from ...logger import Logger
+from ..decorators import with_retries
+from ..exception import HardwareInitializationError
+from .modulation import RFM9xModulation
 
 try:
     from lib.adafruit_rfm.rfm9x import RFM9x
     from lib.adafruit_rfm.rfm9xfsk import RFM9xFSK
 except ImportError:
     from mocks.circuitpython.adafruit_rfm.rfm9x import RFM9x  # type: ignore
-    from mocks.circuitpython.adafruit_rfm.rfm9xfsk import RFM9xFSK  # type: ignore
+    from mocks.circuitpython.adafruit_rfm.rfm9xfsk import \
+        RFM9xFSK  # type: ignore
 
 # Type hinting only
 try:
     from busio import SPI
     from digitalio import DigitalInOut
-
     from lib.adafruit_rfm.rfm_common import RFMSPI
 except ImportError:
     pass

--- a/pysquared/hardware/rfm9x/manager.py
+++ b/pysquared/hardware/rfm9x/manager.py
@@ -5,7 +5,6 @@ try:
     from typing import Any
 
     from lib.adafruit_rfm.rfm_common import RFMSPI
-
     from pysquared.hardware.rfm9x.factory import RFM9xFactory
     from pysquared.logger import Logger
     from pysquared.nvm.flag import Flag

--- a/pysquared/hardware/rfm9x/manager.py
+++ b/pysquared/hardware/rfm9x/manager.py
@@ -1,10 +1,11 @@
-from pysquared.hardware.rfm9x.modulation import RFM9xModulation
+from .modulation import RFM9xModulation
 
 # Type hinting only
 try:
     from typing import Any
 
     from lib.adafruit_rfm.rfm_common import RFMSPI
+
     from pysquared.hardware.rfm9x.factory import RFM9xFactory
     from pysquared.logger import Logger
     from pysquared.nvm.flag import Flag

--- a/pysquared/logger.py
+++ b/pysquared/logger.py
@@ -8,7 +8,7 @@ import time
 import traceback
 from collections import OrderedDict
 
-from pysquared.nvm.counter import Counter
+from .nvm.counter import Counter
 
 
 def _color(msg, color="gray", fmt="normal"):

--- a/pysquared/packet_manager.py
+++ b/pysquared/packet_manager.py
@@ -1,6 +1,6 @@
 # Written with Claude 3.5
 # Nov 10, 2024
-from pysquared.logger import Logger
+from .logger import Logger
 
 try:
     from typing import Union

--- a/pysquared/packet_sender.py
+++ b/pysquared/packet_sender.py
@@ -1,6 +1,6 @@
-from pysquared.hardware.rfm9x.manager import RFM9xManager
-from pysquared.logger import Logger
-from pysquared.packet_manager import PacketManager
+from .hardware.rfm9x.manager import RFM9xManager
+from .logger import Logger
+from .packet_manager import PacketManager
 
 try:
     from typing import Union

--- a/pysquared/pysquared.py
+++ b/pysquared/pysquared.py
@@ -25,11 +25,12 @@ import lib.adafruit_lis2mdl as adafruit_lis2mdl  # Magnetometer
 import lib.adafruit_tca9548a as adafruit_tca9548a  # I2C Multiplexer
 import lib.neopixel as neopixel  # RGB LED
 import lib.rv3028.rv3028 as rv3028  # Real Time Clock
-import pysquared.nvm.register as register
 from lib.adafruit_lsm6ds.lsm6dsox import LSM6DSOX  # IMU
-from pysquared.config.config import Config  # Configs
-from pysquared.nvm.counter import Counter
-from pysquared.nvm.flag import Flag
+
+from .config.config import Config  # Configs
+from .nvm import register
+from .nvm.counter import Counter
+from .nvm.flag import Flag
 
 try:
     from typing import Any, Callable, Optional, OrderedDict, TextIO, Union
@@ -38,7 +39,7 @@ try:
 except Exception:
     pass
 
-from pysquared.logger import Logger
+from .logger import Logger
 
 SEND_BUFF: bytearray = bytearray(252)
 

--- a/pysquared/sleep_helper.py
+++ b/pysquared/sleep_helper.py
@@ -4,8 +4,8 @@ import time
 import alarm
 import digitalio
 
-from pysquared.logger import Logger
-from pysquared.pysquared import Satellite
+from .logger import Logger
+from .pysquared import Satellite
 
 try:
     from typing import Literal


### PR DESCRIPTION
## Summary
Specifies the pysquared package in the pyproject.toml so that other repos can pull pysquared from their requirements.txt. Also changes pysquared to use relative imports so there isn't import issues when pulling pysquared onto a board.

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
