### PR TITLE
Fix pin can't be serialized log message

### DIFF
--- a/pysquared/watchdog.py
+++ b/pysquared/watchdog.py
@@ -25,7 +25,7 @@ class Watchdog:
         """
         self._log = logger
 
-        self._log.debug("Initializing watchdog", pin=pin)
+        self._log.debug("Initializing watchdog")
 
         self._digital_in_out: DigitalInOut = initialize_pin(
             logger,


### PR DESCRIPTION
## Summary
Fix pin can't be serialized log message.

## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
