### PR TITLE
Adding functionality to serialize invalid types as strings

### DIFF
--- a/pysquared/hardware/digitalio.py
+++ b/pysquared/hardware/digitalio.py
@@ -21,10 +21,7 @@ def initialize_pin(
 
     :return ~digitalio.DigitalInOut: The initialized DigitalInOut object.
     """
-    logger.debug(
-        message="Initializing pin",
-        initial_value=initial_value,
-    )
+    logger.debug(message="Initializing pin", initial_value=initial_value, pin=pin)
 
     try:
         digital_in_out = DigitalInOut(pin)

--- a/pysquared/logger.py
+++ b/pysquared/logger.py
@@ -86,6 +86,8 @@ class Logger:
         json_order: OrderedDict[str, str] = OrderedDict(
             [("time", asctime), ("level", level), ("msg", message)]
         )
+
+        # detect if there are kwargs with invalid types (would cause TypeError) and converting object to string type, making it loggable
         for key, value in kwargs.items():
             if not self.is_valid_json_type(value):
                 kwargs[key] = str(value)

--- a/pysquared/logger.py
+++ b/pysquared/logger.py
@@ -63,7 +63,7 @@ class Logger:
     def _can_print_this_level(self, level_value: int) -> bool:
         return level_value >= self._log_level
 
-    def is_valid_json_type(self, object) -> bool:
+    def _is_valid_json_type(self, object) -> bool:
         valid_types = {dict, list, tuple, str, int, float, bool, None}
 
         return type(object) in valid_types
@@ -89,7 +89,7 @@ class Logger:
 
         # detect if there are kwargs with invalid types (would cause TypeError) and converting object to string type, making it loggable
         for key, value in kwargs.items():
-            if not self.is_valid_json_type(value):
+            if not self._is_valid_json_type(value):
                 kwargs[key] = str(value)
 
         json_order.update(kwargs)

--- a/pysquared/logger.py
+++ b/pysquared/logger.py
@@ -63,6 +63,11 @@ class Logger:
     def _can_print_this_level(self, level_value: int) -> bool:
         return level_value >= self._log_level
 
+    def isValidJSONType(self, object) -> bool:
+        valid_types = {dict, list, tuple, str, int, float, bool, None}
+
+        return type(object) in valid_types
+
     def _log(self, level: str, level_value: int, message: str, **kwargs) -> None:
         """
         Log a message with a given severity level and any addional key/values.
@@ -81,6 +86,10 @@ class Logger:
         json_order: OrderedDict[str, str] = OrderedDict(
             [("time", asctime), ("level", level), ("msg", message)]
         )
+        for key, value in kwargs.items():
+            if not self.isValidJSONType(value):
+                kwargs[key] = str(value)
+
         json_order.update(kwargs)
 
         try:

--- a/pysquared/logger.py
+++ b/pysquared/logger.py
@@ -63,7 +63,7 @@ class Logger:
     def _can_print_this_level(self, level_value: int) -> bool:
         return level_value >= self._log_level
 
-    def isValidJSONType(self, object) -> bool:
+    def is_valid_json_type(self, object) -> bool:
         valid_types = {dict, list, tuple, str, int, float, bool, None}
 
         return type(object) in valid_types
@@ -87,7 +87,7 @@ class Logger:
             [("time", asctime), ("level", level), ("msg", message)]
         )
         for key, value in kwargs.items():
-            if not self.isValidJSONType(value):
+            if not self.is_valid_json_type(value):
                 kwargs[key] = str(value)
 
         json_order.update(kwargs)

--- a/pysquared/watchdog.py
+++ b/pysquared/watchdog.py
@@ -25,7 +25,7 @@ class Watchdog:
         """
         self._log = logger
 
-        self._log.debug("Initializing watchdog")
+        self._log.debug("Initializing watchdog", pin=pin)
 
         self._digital_in_out: DigitalInOut = initialize_pin(
             logger,

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,8 +1,15 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 import pysquared.nvm.counter as counter
 from mocks.circuitpython.byte_array import ByteArray
 from pysquared.logger import Logger, _color
+
+try:
+    from microcontroller import Pin
+except ImportError:
+    pass
 
 
 @pytest.fixture
@@ -117,14 +124,6 @@ def test_critical_log(capsys, logger):
     assert '"config": "king"' in captured.out
 
 
-def test_type_error_log(capsys, logger):
-    logger.info("Testing type error", bad_arg=lambda x: x + 1)
-    captured = capsys.readouterr()
-    assert '"level": "ERROR"' in captured.out
-    assert "Failed to serialize log message:" in captured.out
-    assert "Object of type function is not JSON serializable" in captured.out
-
-
 def test_debug_log_color(capsys, logger_color):
     logger_color.debug("This is a debug message", blake="jameson")
     captured = capsys.readouterr()
@@ -187,3 +186,21 @@ def test_critical_log_color(capsys, logger_color):
     assert '"soft": "ware"' in captured.out
     assert '"j": "20"' in captured.out
     assert '"config": "king"' in captured.out
+
+
+def test_invalid_json_type_bytes(capsys, logger):
+    byte_message = b"forming a bytes message"
+
+    logger.debug("This is a random message", attempt=byte_message)
+    captured = capsys.readouterr()
+    assert "b'forming a bytes message'" in captured.out
+
+
+# testing a kwarg of value type Pin, which previously caused a
+def test_invalid_json_type_pin(capsys, logger):
+    mock_pin = MagicMock(spec=Pin)
+
+    logger.debug("Initializing watchdog", pin=mock_pin)
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "TypeError" not in captured.out

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -188,19 +188,18 @@ def test_critical_log_color(capsys, logger_color):
     assert '"config": "king"' in captured.out
 
 
+# testing a kwarg of value type bytes, which previously caused a TypeError exception
 def test_invalid_json_type_bytes(capsys, logger):
     byte_message = b"forming a bytes message"
-
     logger.debug("This is a random message", attempt=byte_message)
     captured = capsys.readouterr()
     assert "b'forming a bytes message'" in captured.out
+    assert "TypeError" not in captured.out
 
 
-# testing a kwarg of value type Pin, which previously caused a
+# testing a kwarg of value type Pin, which previously caused a TypeError exception
 def test_invalid_json_type_pin(capsys, logger):
     mock_pin = MagicMock(spec=Pin)
-
     logger.debug("Initializing watchdog", pin=mock_pin)
     captured = capsys.readouterr()
-    print(captured.out)
     assert "TypeError" not in captured.out


### PR DESCRIPTION
## Summary
In recent time, Nate pointed out in https://github.com/proveskit/pysquared/issues/194 that CircuitPython 9,2,1+ "Raises TypeError when attempt to produce JSON for invalid types."

He added code in https://github.com/proveskit/pysquared/pull/206 that gracefully handled TypeError.

I had an idea to detect if an invalid object occurred as a kwarg trying to be parsed and logged, and cast that object to a string if invalid. This results in being able to log the output we had before the changes.

As seen below, the 'pin' kwarg is able to be passed to the logger again and gives descriptive info during the "Initializing pin" and "Initializing watchdog" logs. The previous result would have been a log that said "Failed to serialize log message" 

<img width="1149" alt="Screenshot 2025-04-07 at 6 12 24 PM" src="https://github.com/user-attachments/assets/c86ee7a1-c9f5-45ec-8b51-887de2e2e374" />


## How was this tested
- [x] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
