### PR TITLE
Exclude protocols from code coverage reporting

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,4 @@ sonar.sources=pysquared/
 sonar.tests=mocks/, stubs/, tests/
 
 sonar.python.coverage.reportPaths=.coverage-reports/coverage.xml
+sonar.coverage.exclusions=pysquared/protos/**


### PR DESCRIPTION
## Summary
Functions defined by protocols are run directly and only contain a `pass` or `...` statement. Code coverage is complaining that we don't run them so let's exclude them.

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
