### PR TITLE
Create sx1280 manager

### DIFF
--- a/mocks/proves_sx1280/sx1280.py
+++ b/mocks/proves_sx1280/sx1280.py
@@ -1,0 +1,36 @@
+"""
+Mock for PROVES SX1280
+https://github.com/proveskit/CircuitPython_SX1280/blob/6bcb9fc2922801d1eddbe6cec2b515448c0578ca/proves_sx1280/sx1280.py
+"""
+
+from busio import SPI
+from digitalio import DigitalInOut
+
+
+class SX1280:
+    def __init__(
+        self,
+        spi: SPI,
+        cs: DigitalInOut,
+        reset: DigitalInOut,
+        busy: DigitalInOut,
+        frequency: float,
+        *,
+        debug: bool = False,
+        txen: DigitalInOut | bool = False,
+        rxen: DigitalInOut | bool = False,
+    ) -> None: ...
+
+    def send(
+        self,
+        data,
+        pin=None,
+        irq=False,
+        header=True,
+        ID=0,
+        target=0,
+        action=0,
+        keep_listening=False,
+    ): ...
+
+    def receive(self, continuous=True, keep_listening=True) -> bytearray | None: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "adafruit-circuitpython-veml7700==2.0.2",
     "proves-circuitpython-rv3028 @ git+https://github.com/proveskit/PROVES_CircuitPython_RV3028@1.0.0",
     "proves-circuitpython-sx126 @ git+https://github.com/proveskit/micropySX126X@1.0.0",
+    "proves-circuitpython-sx1280 @ git+https://github.com/proveskit/CircuitPython_SX1280@1.0.1",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "adafruit-circuitpython-veml7700==2.0.2",
     "proves-circuitpython-rv3028 @ git+https://github.com/proveskit/PROVES_CircuitPython_RV3028@1.0.0",
     "proves-circuitpython-sx126 @ git+https://github.com/proveskit/micropySX126X@1.0.0",
-    "proves-circuitpython-sx1280 @ git+https://github.com/proveskit/CircuitPython_SX1280@1.0.1",
+    "proves-circuitpython-sx1280 @ git+https://github.com/proveskit/CircuitPython_SX1280@1.0.3",
 ]
 
 [tool.setuptools]

--- a/pysquared/hardware/radio/manager/sx1280.py
+++ b/pysquared/hardware/radio/manager/sx1280.py
@@ -1,0 +1,97 @@
+from busio import SPI
+from digitalio import DigitalInOut
+from sx1280.sx1280 import SX1280
+
+from ....config.radio import RadioConfig
+from ....logger import Logger
+from ....nvm.flag import Flag
+from ..modulation import LoRa, RadioModulation
+from .base import BaseRadioManager
+
+# Type hinting only
+try:
+    from typing import Optional, Type
+except ImportError:
+    pass
+
+
+class SX1280Manager(BaseRadioManager):
+    """Manager class implementing RadioProto for SX1280 radios."""
+
+    _radio: SX1280
+
+    def __init__(
+        self,
+        logger: Logger,
+        radio_config: RadioConfig,
+        use_fsk: Flag,
+        spi: SPI,
+        chip_select: DigitalInOut,
+        reset: DigitalInOut,
+        busy: DigitalInOut,
+        frequency: float,
+    ) -> None:
+        """Initialize the manager class and the underlying radio hardware.
+
+        :param Logger logger: Logger instance for logging messages.
+        :param RadioConfig radio_config: Radio configuration object.
+        :param Flag use_fsk: Flag to determine whether to use FSK or LoRa mode.
+        :param busio.SPI spi: The SPI bus connected to the chip. Ensure SCK, MOSI, and MISO are connected.
+        :param ~digitalio.DigitalInOut chip_select: Chip select pin.
+        :param ~digitalio.DigitalInOut busy: Interrupt request pin.
+        :param ~digitalio.DigitalInOut reset: Reset pin.
+        :param ~digitalio.DigitalInOut gpio: General purpose IO pin (used by SX1280).
+
+        :raises HardwareInitializationError: If the radio fails to initialize after retries.
+        """
+        self._spi = spi
+        self._chip_select = chip_select
+        self._reset = reset
+        self._busy = busy
+        self._frequency = frequency
+
+        super().__init__(
+            logger=logger,
+            radio_config=radio_config,
+            use_fsk=use_fsk,
+        )
+
+    def _initialize_radio(self, modulation: Type[RadioModulation]) -> None:
+        """Initialize the specific SX1280 radio hardware."""
+        self._radio = SX1280(
+            self._spi,
+            self._chip_select,
+            self._reset,
+            self._busy,
+            frequency=self._frequency,
+        )
+
+    def _send_internal(self, payload: bytes) -> bool:
+        """Send data using the SX1280 radio."""
+        success = self._radio.send(payload)
+        if not success:
+            self._log.warning("Radio send failed")
+
+        return success
+
+    def get_modulation(self) -> Type[RadioModulation]:
+        """Get the modulation mode from the initialized SX1280 radio."""
+        return LoRa
+
+    def receive(self, timeout: Optional[int] = None) -> bytes | None:
+        """Receive data from the radio.
+
+        :param int | None timeout: Optional receive timeout in seconds. If None, use the default timeout.
+        :return: The received data as bytes, or None if no data was received.
+        """
+        try:
+            msg = self._radio.receive(keep_listening=True)
+
+            if msg is None:
+                self._log.debug("No message received")
+                return None
+
+            return bytes(msg)
+        except Exception as e:
+            self._log.error("Error receiving data", e)
+            return None

--- a/pysquared/hardware/radio/manager/sx1280.py
+++ b/pysquared/hardware/radio/manager/sx1280.py
@@ -82,6 +82,7 @@ class SX1280Manager(BaseRadioManager):
 
     def get_modulation(self) -> Type[RadioModulation]:
         """Get the modulation mode from the initialized SX1280 radio."""
+        self._log.warning("SX1280 library does not support FSK modulation, using LoRa")
         return LoRa
 
     def receive(self, timeout: Optional[int] = None) -> bytes | None:

--- a/pysquared/hardware/radio/manager/sx1280.py
+++ b/pysquared/hardware/radio/manager/sx1280.py
@@ -74,11 +74,7 @@ class SX1280Manager(BaseRadioManager):
 
     def _send_internal(self, payload: bytes) -> bool:
         """Send data using the SX1280 radio."""
-        success = self._radio.send(payload)
-        if not success:
-            self._log.warning("Radio send failed")
-
-        return success
+        return bool(self._radio.send(payload))
 
     def get_modulation(self) -> Type[RadioModulation]:
         """Get the modulation mode from the initialized SX1280 radio."""

--- a/pysquared/hardware/radio/manager/sx1280.py
+++ b/pysquared/hardware/radio/manager/sx1280.py
@@ -42,7 +42,8 @@ class SX1280Manager(BaseRadioManager):
         :param ~digitalio.DigitalInOut chip_select: Chip select pin.
         :param ~digitalio.DigitalInOut busy: Interrupt request pin.
         :param ~digitalio.DigitalInOut reset: Reset pin.
-        :param ~digitalio.DigitalInOut gpio: General purpose IO pin (used by SX1280).
+        :param ~digitalio.DigitalInOut txen: Transmit enable pin.
+        :param ~digitalio.DigitalInOut rxen: Receive enable pin.
 
         :raises HardwareInitializationError: If the radio fails to initialize after retries.
         """

--- a/pysquared/hardware/radio/manager/sx1280.py
+++ b/pysquared/hardware/radio/manager/sx1280.py
@@ -30,6 +30,8 @@ class SX1280Manager(BaseRadioManager):
         reset: DigitalInOut,
         busy: DigitalInOut,
         frequency: float,
+        txen: DigitalInOut,
+        rxen: DigitalInOut,
     ) -> None:
         """Initialize the manager class and the underlying radio hardware.
 
@@ -49,6 +51,8 @@ class SX1280Manager(BaseRadioManager):
         self._reset = reset
         self._busy = busy
         self._frequency = frequency
+        self._txen = txen
+        self._rxen = rxen
 
         super().__init__(
             logger=logger,
@@ -64,6 +68,8 @@ class SX1280Manager(BaseRadioManager):
             self._reset,
             self._busy,
             frequency=self._frequency,
+            txen=self._txen,
+            rxen=self._rxen,
         )
 
     def _send_internal(self, payload: bytes) -> bool:

--- a/pysquared/hardware/radio/manager/sx1280.py
+++ b/pysquared/hardware/radio/manager/sx1280.py
@@ -1,6 +1,6 @@
 from busio import SPI
 from digitalio import DigitalInOut
-from sx1280.sx1280 import SX1280
+from proves_sx1280.sx1280 import SX1280
 
 from ....config.radio import RadioConfig
 from ....logger import Logger

--- a/tests/unit/hardware/radio/manager/test_sx1280_manager.py
+++ b/tests/unit/hardware/radio/manager/test_sx1280_manager.py
@@ -1,0 +1,733 @@
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from busio import SPI
+from digitalio import DigitalInOut
+
+from mocks.adafruit_rfm.rfm9x import RFM9x
+from mocks.circuitpython.byte_array import ByteArray
+from mocks.proves_sx1280.sx1280 import SX1280
+from pysquared.config.radio import RadioConfig
+from pysquared.hardware.exception import HardwareInitializationError
+from pysquared.hardware.radio.manager.sx1280 import SX1280Manager
+from pysquared.hardware.radio.modulation import FSK, LoRa
+from pysquared.logger import Logger
+from pysquared.nvm.flag import Flag
+
+
+@pytest.fixture
+def mock_spi() -> MagicMock:
+    return MagicMock(spec=SPI)
+
+
+@pytest.fixture
+def mock_chip_select() -> MagicMock:
+    return MagicMock(spec=DigitalInOut)
+
+
+@pytest.fixture
+def mock_reset() -> MagicMock:
+    return MagicMock(spec=DigitalInOut)
+
+
+@pytest.fixture
+def mock_busy() -> MagicMock:
+    return MagicMock(spec=DigitalInOut)
+
+
+@pytest.fixture
+def mock_txen() -> MagicMock:
+    return MagicMock(spec=DigitalInOut)
+
+
+@pytest.fixture
+def mock_rxen() -> MagicMock:
+    return MagicMock(spec=DigitalInOut)
+
+
+@pytest.fixture
+def mock_logger() -> MagicMock:
+    return MagicMock(spec=Logger)
+
+
+@pytest.fixture
+def mock_use_fsk() -> MagicMock:
+    return MagicMock(spec=Flag)
+
+
+@pytest.fixture
+def mock_radio_config() -> RadioConfig:
+    return RadioConfig(
+        {
+            "license": "testlicense",
+            "sender_id": 1,
+            "receiver_id": 2,
+            "transmit_frequency": 915,
+            "start_time": 0,
+            "fsk": {"broadcast_address": 255, "node_address": 1, "modulation_type": 0},
+            "lora": {
+                "ack_delay": 0.2,
+                "coding_rate": 5,
+                "cyclic_redundancy_check": True,
+                "spreading_factor": 7,
+                "transmit_power": 23,
+            },
+        }
+    )
+
+
+@pytest.fixture
+def mock_sx1280(
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+) -> Generator[MagicMock, None, None]:
+    with patch("pysquared.hardware.radio.manager.sx1280.SX1280") as mock_class:
+        mock_class.return_value = SX1280(
+            mock_spi,
+            mock_chip_select,
+            mock_reset,
+            mock_busy,
+            frequency=2.4,
+            txen=mock_txen,
+            rxen=mock_rxen,
+        )
+        yield mock_class
+
+
+def test_init_fsk_success(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test successful initialization when use_fsk flag is True."""
+    mock_use_fsk.get.return_value = True
+    mock_radio_instance = MagicMock(spec=SX1280)
+    mock_sx1280.return_value = mock_radio_instance
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    mock_sx1280.assert_called_once_with(
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        frequency=2.4,
+        txen=mock_txen,
+        rxen=mock_rxen,
+    )
+    assert manager._radio == mock_radio_instance
+    mock_logger.debug.assert_called_with(
+        "Initializing radio", radio_type="SX1280Manager", modulation=FSK
+    )
+
+
+def test_init_lora_success(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test successful initialization when use_fsk flag is False."""
+    mock_use_fsk.get.return_value = False
+    mock_radio_instance = MagicMock(spec=SX1280)
+    mock_sx1280.return_value = mock_radio_instance
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    mock_sx1280.assert_called_once_with(
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        frequency=2.4,
+        txen=mock_txen,
+        rxen=mock_rxen,
+    )
+    assert manager._radio == mock_radio_instance
+    mock_logger.debug.assert_called_with(
+        "Initializing radio", radio_type="SX1280Manager", modulation=LoRa
+    )
+
+
+@pytest.mark.slow
+def test_init_with_retries_fsk(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test successful initialization when use_fsk flag is True."""
+    mock_use_fsk.get.return_value = True
+    mock_sx1280.side_effect = Exception("Simulated FSK failure")
+
+    with pytest.raises(HardwareInitializationError):
+        SX1280Manager(
+            mock_logger,
+            mock_radio_config,
+            mock_use_fsk,
+            mock_spi,
+            mock_chip_select,
+            mock_reset,
+            mock_busy,
+            2.4,
+            mock_txen,
+            mock_rxen,
+        )
+
+    mock_logger.debug.assert_called_with(
+        "Initializing radio", radio_type="SX1280Manager", modulation=FSK
+    )
+    assert mock_sx1280.call_count == 3
+
+
+@pytest.mark.slow
+def test_init_with_retries_lora(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test successful initialization when use_fsk flag is False."""
+    mock_use_fsk.get.return_value = True
+    mock_sx1280.side_effect = Exception("Simulated FSK failure")
+
+    with pytest.raises(HardwareInitializationError):
+        SX1280Manager(
+            mock_logger,
+            mock_radio_config,
+            mock_use_fsk,
+            mock_spi,
+            mock_chip_select,
+            mock_reset,
+            mock_busy,
+            2.4,
+            mock_txen,
+            mock_rxen,
+        )
+
+    mock_logger.debug.assert_called_with(
+        "Initializing radio", radio_type="SX1280Manager", modulation=FSK
+    )
+    assert mock_sx1280.call_count == 3
+
+
+# Test send Method
+def test_send_success_bytes(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test successful sending of bytes."""
+    mock_use_fsk.get.return_value = False
+    mock_radio_instance = MagicMock(spec=RFM9x)
+    mock_radio_instance.send = MagicMock()
+    mock_radio_instance.send.return_value = True  # Simulate successful send
+    mock_sx1280.return_value = mock_radio_instance
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    msg = b"Hello Radio"
+    result = manager.send(msg)
+
+    license_bytes: bytes = bytes(mock_radio_config.license, "UTF-8")
+    expected_msg: bytes = b" ".join([license_bytes, msg, license_bytes])
+
+    assert result is True
+    mock_radio_instance.send.assert_called_once_with(expected_msg)
+    mock_logger.info.assert_called_once_with("Radio message sent")
+
+
+def test_send_success_string(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test successful sending of a string (should be converted to bytes)."""
+    mock_use_fsk.get.return_value = False
+    mock_radio_instance = MagicMock(spec=RFM9x)
+    mock_radio_instance.send = MagicMock()
+    mock_radio_instance.send.return_value = True
+    mock_sx1280.return_value = mock_radio_instance
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    data_str = "Hello String"
+    expected_bytes: bytes = b" ".join(
+        [
+            bytes(mock_radio_config.license, "UTF-8"),
+            bytes(data_str, "UTF-8"),
+            bytes(mock_radio_config.license, "UTF-8"),
+        ]
+    )
+
+    result = manager.send(data_str)
+
+    assert result is True
+    mock_radio_instance.send.assert_called_once_with(expected_bytes)
+    mock_logger.info.assert_called_once_with("Radio message sent")
+
+
+def test_send_unexpected_type(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test successful sending of a string (should be converted to bytes)."""
+    mock_use_fsk.get.return_value = False
+    mock_radio_instance = MagicMock(spec=RFM9x)
+    mock_radio_instance.send = MagicMock()
+    mock_radio_instance.send.return_value = True
+    mock_sx1280.return_value = mock_radio_instance
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    result = manager.send(manager)
+    assert result is True
+
+    mock_radio_instance.send.assert_called_once_with(
+        bytes(f"testlicense {manager} testlicense", "UTF-8")
+    )
+    mock_logger.warning.assert_called_once_with(
+        "Attempting to send non-bytes/str data type: <class 'pysquared.hardware.radio.manager.sx1280.SX1280Manager'>",
+    )
+
+
+def test_send_unlicensed(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test send attempt when not licensed."""
+    mock_use_fsk.get.return_value = False
+    mock_radio_instance = MagicMock(spec=RFM9x)
+    mock_radio_instance.send = MagicMock()
+    mock_sx1280.return_value = mock_radio_instance
+
+    mock_radio_config.license = ""  # Simulate unlicensed state
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    result = manager.send(b"test")
+
+    assert result is False
+    mock_radio_instance.send.assert_not_called()
+    mock_logger.warning.assert_called_once_with(
+        "Radio send attempt failed: Not licensed."
+    )
+
+
+def test_send_exception(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test handling of exception during radio.send()."""
+    mock_use_fsk.get.return_value = False
+    mock_radio_instance = MagicMock(spec=RFM9x)
+    mock_radio_instance.send = MagicMock()
+    send_error = RuntimeError("SPI Error")
+    mock_radio_instance.send.side_effect = send_error
+    mock_sx1280.return_value = mock_radio_instance
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    result = manager.send(b"test")
+
+    assert result is False
+    mock_logger.error.assert_called_once_with("Error sending radio message", send_error)
+
+
+@patch("pysquared.nvm.flag.microcontroller")
+def test_set_modulation_lora_to_fsk(
+    mock_microcontroller: MagicMock,
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test toggling the modulation flag."""
+    mock_microcontroller.nvm = ByteArray(size=1)
+    use_fsk = Flag(0, 0)
+
+    # Start as LoRa
+    use_fsk.toggle(False)
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+    assert manager.get_modulation() == LoRa
+    assert use_fsk.get() is False
+
+    # Request FSK
+    manager.set_modulation(FSK)
+    assert use_fsk.get() is False
+    mock_logger.info.assert_called_with(
+        "Radio modulation change requested for next init",
+        requested=FSK,
+        current=LoRa,
+    )
+
+
+@patch("pysquared.nvm.flag.microcontroller")
+def test_set_modulation_fsk_to_lora(
+    mock_microcontroller: MagicMock,
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test toggling the modulation flag."""
+    mock_microcontroller.nvm = ByteArray(size=1)
+    use_fsk = Flag(0, 0)
+
+    # Start as FSK
+    use_fsk.toggle(True)
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+    assert manager.get_modulation() == LoRa
+    assert use_fsk.get() is True
+
+    # Request LoRa
+    manager.set_modulation(LoRa)
+    mock_logger.info.assert_not_called()
+    mock_logger.warning.assert_called_with(
+        "SX1280 library does not support FSK modulation, using LoRa"
+    )
+
+
+def test_get_modulation_initialized(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test get_modulation when radio is initialized."""
+    # Test FSK instance
+    mock_use_fsk.get.return_value = True
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+    assert manager.get_modulation() == LoRa
+
+    # Test LoRa instance
+    mock_use_fsk.get.return_value = False
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+    assert manager.get_modulation() == LoRa
+
+
+def test_receive_success(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test successful reception of a message."""
+    mock_use_fsk.get.return_value = False
+    mock_radio_instance = MagicMock(spec=RFM9x)
+    expected_data = b"Received Data"
+    mock_radio_instance.receive = MagicMock()
+    mock_radio_instance.receive.return_value = expected_data
+    mock_sx1280.return_value = mock_radio_instance
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    received_data = manager.receive(timeout=10)
+
+    assert received_data == expected_data
+    mock_radio_instance.receive.assert_called_once_with(keep_listening=True)
+    mock_logger.error.assert_not_called()
+
+
+def test_receive_no_message(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test receiving when no message is available (timeout)."""
+    mock_use_fsk.get.return_value = False
+    mock_radio_instance = MagicMock(spec=RFM9x)
+    mock_radio_instance.receive = MagicMock()
+    mock_radio_instance.receive.return_value = None  # Simulate timeout
+    mock_sx1280.return_value = mock_radio_instance
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    received_data = manager.receive(timeout=10)
+
+    assert received_data is None
+    mock_radio_instance.receive.assert_called_once_with(keep_listening=True)
+    mock_logger.debug.assert_called_with("No message received")
+    mock_logger.error.assert_not_called()
+
+
+def test_receive_exception(
+    mock_sx1280: MagicMock,
+    mock_logger: MagicMock,
+    mock_spi: MagicMock,
+    mock_chip_select: MagicMock,
+    mock_reset: MagicMock,
+    mock_busy: MagicMock,
+    mock_txen: MagicMock,
+    mock_rxen: MagicMock,
+    mock_radio_config: RadioConfig,
+    mock_use_fsk: MagicMock,
+):
+    """Test handling of exception during radio.receive()."""
+    mock_use_fsk.get.return_value = False
+    mock_radio_instance = MagicMock(spec=RFM9x)
+    mock_radio_instance.receive = MagicMock()
+    receive_error = RuntimeError("Receive Error")
+    mock_radio_instance.receive.side_effect = receive_error
+    mock_sx1280.return_value = mock_radio_instance
+
+    manager = SX1280Manager(
+        mock_logger,
+        mock_radio_config,
+        mock_use_fsk,
+        mock_spi,
+        mock_chip_select,
+        mock_reset,
+        mock_busy,
+        2.4,
+        mock_txen,
+        mock_rxen,
+    )
+
+    received_data = manager.receive()
+
+    assert received_data is None
+    mock_radio_instance.receive.assert_called_once_with(keep_listening=True)
+    mock_logger.error.assert_called_once_with("Error receiving data", receive_error)

--- a/uv.lock
+++ b/uv.lock
@@ -456,6 +456,17 @@ version = "2.0.0"
 source = { git = "https://github.com/proveskit/micropySX126X?rev=1.0.0#247e623588b6c7b4a273c5b5aa9d35fc1b1d2f80" }
 
 [[package]]
+name = "proves-circuitpython-sx1280"
+version = "1.0.2"
+source = { git = "https://github.com/proveskit/CircuitPython_SX1280?rev=1.0.3#6bcb9fc2922801d1eddbe6cec2b515448c0578ca" }
+dependencies = [
+    { name = "adafruit-circuitpython-typing" },
+    { name = "circuitpython-stubs" },
+    { name = "pre-commit" },
+    { name = "pyright", extra = ["nodejs"] },
+]
+
+[[package]]
 name = "pyftdi"
 version = "0.56.0"
 source = { registry = "https://pypi.org/simple" }
@@ -517,6 +528,7 @@ dependencies = [
     { name = "pre-commit" },
     { name = "proves-circuitpython-rv3028" },
     { name = "proves-circuitpython-sx126" },
+    { name = "proves-circuitpython-sx1280" },
     { name = "pyright", extra = ["nodejs"] },
     { name = "pytest" },
 ]
@@ -541,6 +553,7 @@ requires-dist = [
     { name = "pre-commit", specifier = "==4.0.1" },
     { name = "proves-circuitpython-rv3028", git = "https://github.com/proveskit/PROVES_CircuitPython_RV3028?rev=1.0.0" },
     { name = "proves-circuitpython-sx126", git = "https://github.com/proveskit/micropySX126X?rev=1.0.0" },
+    { name = "proves-circuitpython-sx1280", git = "https://github.com/proveskit/CircuitPython_SX1280?rev=1.0.3" },
     { name = "pyright", extras = ["nodejs"], specifier = "==1.1.399" },
     { name = "pytest", specifier = "==8.3.2" },
 ]


### PR DESCRIPTION
## Summary
This pull request introduces support for the SX1280 radio module by adding a mock implementation, updating dependencies, and creating a new manager class for handling SX1280 radios.

## How was this tested
- [x] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)

This has been tested on the v5a development branch but I don't have screenshots or a board on me atm.
