### PR TITLE
Add identifiable packets through a counter

### DIFF
--- a/pysquared/hardware/radio/packetizer/packet_manager.py
+++ b/pysquared/hardware/radio/packetizer/packet_manager.py
@@ -172,10 +172,10 @@ class PacketManager:
 
         return b"".join(self._get_payload(packet) for packet in sorted_packets)
 
-    def _get_header(self, packet: bytes) -> tuple[str, int, int, int]:
+    def _get_header(self, packet: bytes) -> tuple[int, int, int, int]:
         """Returns the sequence number and total packets stored in the header."""
         return (
-            int.from_bytes(packet[0:1], "big"),
+            int.from_bytes(packet[0:1], "big"),  # packet identifier
             int.from_bytes(packet[1:3], "big"),  # sequence number
             int.from_bytes(packet[3:5], "big"),  # total packets
             -int.from_bytes(packet[5:6], "big"),  # RSSI

--- a/pysquared/hardware/radio/packetizer/packet_manager.py
+++ b/pysquared/hardware/radio/packetizer/packet_manager.py
@@ -2,6 +2,7 @@ import math
 import time
 
 from ....logger import Logger
+from ....nvm.counter import Counter
 from ....protos.radio import RadioProto
 
 try:
@@ -17,6 +18,7 @@ class PacketManager:
         logger: Logger,
         radio: RadioProto,
         license: str,
+        message_counter: Counter,
         send_delay: float = 0.2,
     ) -> None:
         """Initialize the packet manager with maximum packet size"""
@@ -24,10 +26,10 @@ class PacketManager:
         self._radio: RadioProto = radio
         self._send_delay: float = send_delay
         self._license: str = license
-        self._header_size: int = (
-            5  # 2 bytes for sequence number, 2 for total packets, 1 for rssi
-        )
+        # 1 byte for packet identifier, 2 bytes for sequence number, 2 for total packets, 1 for rssi
+        self._header_size: int = 6
         self._payload_size: int = radio.get_max_packet_size() - self._header_size
+        self._message_counter: Counter = message_counter
 
     def send(self, data: bytes) -> bool:
         """Send data"""
@@ -55,8 +57,10 @@ class PacketManager:
         """
         Takes input data and returns a list of packets ready for transmission
         Each packet includes:
+        - 1 byte: packet identifier
         - 2 bytes: sequence number (0-based)
         - 2 bytes: total number of packets
+        - 1 byte: rssi
         - remaining bytes: payload
         """
         # Calculate number of packets needed
@@ -67,11 +71,14 @@ class PacketManager:
             data_length=len(data),
         )
 
+        packet_identifier: int = self._get_packet_identifier()
+
         packets: list[bytes] = []
         for sequence_number in range(total_packets):
             # Create header
             header: bytes = (
-                sequence_number.to_bytes(2, "big")
+                packet_identifier.to_bytes(1, "big")
+                + sequence_number.to_bytes(2, "big")
                 + total_packets.to_bytes(2, "big")
                 + abs(self._radio.get_rssi()).to_bytes(1, "big")
             )
@@ -117,6 +124,8 @@ class PacketManager:
             if packet is None:
                 continue
 
+            packet_identifier, _, total_packets, _ = self._get_header(packet)
+
             # Log received packets
             self._logger.debug(
                 "Received packet",
@@ -125,11 +134,19 @@ class PacketManager:
                 payload=self._get_payload(packet),
             )
 
-            # Process received packet
+            if received_packets:
+                (
+                    first_packet_identifier,
+                    _,
+                    _,
+                    _,
+                ) = self._get_header(received_packets[0])
+                if packet_identifier != first_packet_identifier:
+                    continue
+
             received_packets.append(packet)
 
             # Check if we have all packets
-            _, total_packets, _ = self._get_header(packet)
             if total_packets == len(received_packets):
                 self._logger.debug(
                     "Received all expected packets", received=total_packets
@@ -150,19 +167,25 @@ class PacketManager:
         Returns None if packets are missing or corrupted
         """
         sorted_packets: list = sorted(
-            packets, key=lambda p: int.from_bytes(p[:2], "big")
+            packets, key=lambda p: int.from_bytes(p[1:3], "big")
         )
 
         return b"".join(self._get_payload(packet) for packet in sorted_packets)
 
-    def _get_header(self, packet: bytes) -> tuple[int, int, int]:
+    def _get_header(self, packet: bytes) -> tuple[str, int, int, int]:
         """Returns the sequence number and total packets stored in the header."""
         return (
-            int.from_bytes(packet[0:2], "big"),  # sequence number
-            int.from_bytes(packet[2:4], "big"),  # total packets
-            -int.from_bytes(packet[4:5], "big"),  # RSSI
+            int.from_bytes(packet[0:1], "big"),
+            int.from_bytes(packet[1:3], "big"),  # sequence number
+            int.from_bytes(packet[3:5], "big"),  # total packets
+            -int.from_bytes(packet[5:6], "big"),  # RSSI
         )
 
     def _get_payload(self, packet: bytes) -> bytes:
         """Returns the payload of the packet."""
         return packet[self._header_size :]
+
+    def _get_packet_identifier(self) -> int:
+        """Increments message_counter and returns the current identifier for a packet"""
+        self._message_counter.increment()
+        return self._message_counter.get()

--- a/tests/unit/hardware/radio/packetizer/test_packet_manager.py
+++ b/tests/unit/hardware/radio/packetizer/test_packet_manager.py
@@ -5,6 +5,7 @@ import pytest
 
 from pysquared.hardware.radio.packetizer.packet_manager import PacketManager
 from pysquared.logger import Logger
+from pysquared.nvm.counter import Counter
 from pysquared.protos.radio import RadioProto
 
 
@@ -21,24 +22,36 @@ def mock_radio() -> MagicMock:
     return radio
 
 
-def test_packet_manager_init(mock_logger, mock_radio):
+@pytest.fixture
+def mock_message_counter() -> MagicMock:
+    counter = MagicMock(spec=Counter)
+    counter.get.return_value = 1
+    return counter
+
+
+def test_packet_manager_init(mock_logger, mock_radio, mock_message_counter):
     """Test PacketManager initialization."""
     license_str = "TEST_LICENSE"
 
-    packet_manager = PacketManager(mock_logger, mock_radio, license_str, send_delay=0.5)
+    packet_manager = PacketManager(
+        mock_logger, mock_radio, license_str, mock_message_counter, send_delay=0.5
+    )
 
     assert packet_manager._logger is mock_logger
     assert packet_manager._radio is mock_radio
     assert packet_manager._license == license_str
+    assert packet_manager._message_counter is mock_message_counter
     assert packet_manager._send_delay == 0.5
-    assert packet_manager._header_size == 5
-    assert packet_manager._payload_size == 95  # 100 - 5 header bytes
+    assert packet_manager._header_size == 6
+    assert packet_manager._payload_size == 94  # 100 - 6 header bytes
 
 
-def test_pack_data_single_packet(mock_logger, mock_radio):
+def test_pack_data_single_packet(mock_logger, mock_radio, mock_message_counter):
     """Test packing data that fits in a single packet."""
     license_str = "TEST"
-    packet_manager = PacketManager(mock_logger, mock_radio, license_str)
+    packet_manager = PacketManager(
+        mock_logger, mock_radio, license_str, mock_message_counter
+    )
 
     # Create test data that fits in a single packet
     test_data = b"Small test data"
@@ -50,24 +63,28 @@ def test_pack_data_single_packet(mock_logger, mock_radio):
     assert len(packet) == len(test_data) + packet_manager._header_size
 
     # Check header
-    sequence_number = int.from_bytes(packet[0:2], "big")
-    total_packets = int.from_bytes(packet[2:4], "big")
-    rssi = int.from_bytes(packet[4:5], "big")
-    payload = packet[5:]
+    packet_identifier = int.from_bytes(packet[0:1], "big")
+    sequence_number = int.from_bytes(packet[1:3], "big")
+    total_packets = int.from_bytes(packet[3:5], "big")
+    rssi = int.from_bytes(packet[5:6], "big")
+    payload = packet[6:]
 
+    assert packet_identifier == mock_message_counter.get()
     assert sequence_number == 0
     assert total_packets == 1
     assert rssi == 70
     assert payload == test_data
 
 
-def test_pack_data_multiple_packets(mock_logger, mock_radio):
+def test_pack_data_multiple_packets(mock_logger, mock_radio, mock_message_counter):
     """Test packing data that requires multiple packets."""
     license_str = "TEST"
-    packet_manager = PacketManager(mock_logger, mock_radio, license_str)
+    packet_manager = PacketManager(
+        mock_logger, mock_radio, license_str, mock_message_counter
+    )
 
     # Create test data that requires multiple packets
-    # With a payload size of 96, this will require 3 packets
+    # With a payload size of 94, this will require 3 packets
     test_data = b"X" * 250
     packets = packet_manager._pack_data(test_data)
     assert len(packets) == 3
@@ -76,11 +93,13 @@ def test_pack_data_multiple_packets(mock_logger, mock_radio):
     reconstructed_data = b""
 
     for i, packet in enumerate(packets):
-        sequence_number = int.from_bytes(packet[0:2], "big")
-        total_packets = int.from_bytes(packet[2:4], "big")
-        rssi = int.from_bytes(packet[4:5], "big")
-        payload = packet[5:]
+        packet_identifier = int.from_bytes(packet[0:1], "big")
+        sequence_number = int.from_bytes(packet[1:3], "big")
+        total_packets = int.from_bytes(packet[3:5], "big")
+        rssi = int.from_bytes(packet[5:6], "big")
+        payload = packet[6:]
 
+        assert packet_identifier == mock_message_counter.get()
         assert sequence_number == i
         assert total_packets == 3
         assert rssi == 70
@@ -91,14 +110,16 @@ def test_pack_data_multiple_packets(mock_logger, mock_radio):
 
 
 @patch("time.sleep")
-def test_send_success(mock_sleep, mock_logger, mock_radio):
+def test_send_success(mock_sleep, mock_logger, mock_radio, mock_message_counter):
     """Test successful execution of send method."""
     license_str = "TEST"
 
-    packet_manager = PacketManager(mock_logger, mock_radio, license_str, send_delay=0.1)
+    packet_manager = PacketManager(
+        mock_logger, mock_radio, license_str, mock_message_counter, send_delay=0.1
+    )
 
     # Create small test data
-    test_data = b'{"message": "test beacon"}'
+    test_data = b"""{"message": "test beacon"}"""
     _ = packet_manager.send(test_data)
 
     # Calculate number of packets that would be created
@@ -120,11 +141,15 @@ def test_send_success(mock_sleep, mock_logger, mock_radio):
 
 
 @patch("time.sleep")
-def test_send_success_multipacket(mock_sleep, mock_logger, mock_radio):
+def test_send_success_multipacket(
+    mock_sleep, mock_logger, mock_radio, mock_message_counter
+):
     """Test successful execution of send method."""
     license_str = "TEST"
 
-    packet_manager = PacketManager(mock_logger, mock_radio, license_str, send_delay=0.1)
+    packet_manager = PacketManager(
+        mock_logger, mock_radio, license_str, mock_message_counter, send_delay=0.1
+    )
 
     # Create test data that requires multiple packets (> 252 bytes)
     test_data = bytes([random.randint(0, 255) for _ in range(300)])
@@ -149,11 +174,13 @@ def test_send_success_multipacket(mock_sleep, mock_logger, mock_radio):
     )
 
 
-def test_send_unlicensed(mock_logger, mock_radio):
+def test_send_unlicensed(mock_logger, mock_radio, mock_message_counter):
     """Test unlicensed execution of send method."""
     license_str = ""
 
-    packet_manager = PacketManager(mock_logger, mock_radio, license_str, send_delay=0.1)
+    packet_manager = PacketManager(
+        mock_logger, mock_radio, license_str, mock_message_counter, send_delay=0.1
+    )
 
     test_data = b"hello world"
     _ = packet_manager.send(test_data)
@@ -163,25 +190,28 @@ def test_send_unlicensed(mock_logger, mock_radio):
 
 
 @patch("time.time")
-def test_unpack_data(mock_time, mock_logger, mock_radio):
+def test_unpack_data(mock_time, mock_logger, mock_radio, mock_message_counter):
     """Test unpacking data from received packets."""
-    packet_manager = PacketManager(mock_logger, mock_radio, "")
+    packet_manager = PacketManager(mock_logger, mock_radio, "", mock_message_counter)
 
     # Create test packets with proper headers
     packet1 = (
-        (0).to_bytes(2, "big")
+        (1).to_bytes(1, "big")
+        + (0).to_bytes(2, "big")
         + (3).to_bytes(2, "big")
         + (70).to_bytes(1, "big")
         + b"first"
     )
     packet2 = (
-        (1).to_bytes(2, "big")
+        (1).to_bytes(1, "big")
+        + (1).to_bytes(2, "big")
         + (3).to_bytes(2, "big")
         + (70).to_bytes(1, "big")
         + b" second"
     )
     packet3 = (
-        (2).to_bytes(2, "big")
+        (1).to_bytes(1, "big")
+        + (2).to_bytes(2, "big")
         + (3).to_bytes(2, "big")
         + (70).to_bytes(1, "big")
         + b" third"
@@ -199,23 +229,25 @@ def test_unpack_data(mock_time, mock_logger, mock_radio):
 
 
 @patch("time.time")
-def test_receive_success(mock_time, mock_logger, mock_radio):
+def test_receive_success(mock_time, mock_logger, mock_radio, mock_message_counter):
     """Test successfully receiving all packets."""
-    packet_manager = PacketManager(mock_logger, mock_radio, "")
+    packet_manager = PacketManager(mock_logger, mock_radio, "", mock_message_counter)
 
     # Set up mock time to control the flow
     mock_time.side_effect = [10.0, 10.1, 10.2, 10.3, 10.4]
 
     # Create test packets
     packet1 = (
-        (0).to_bytes(2, "big")
+        (1).to_bytes(1, "big")
+        + (0).to_bytes(2, "big")
         + (2).to_bytes(2, "big")
         + (70).to_bytes(1, "big")
         + b"first"
     )
     packet2 = None
     packet3 = (
-        (1).to_bytes(2, "big")
+        (1).to_bytes(1, "big")
+        + (1).to_bytes(2, "big")
         + (2).to_bytes(2, "big")
         + (70).to_bytes(1, "big")
         + b" second"
@@ -236,16 +268,16 @@ def test_receive_success(mock_time, mock_logger, mock_radio):
     mock_logger.debug.assert_any_call(
         "Received packet",
         packet_length=len(packet1),
-        header=(0, 2, -70),
+        header=(1, 0, 2, -70),
         payload=b"first",
     )
     mock_logger.debug.assert_any_call("Received all expected packets", received=2)
 
 
 @patch("time.time")
-def test_receive_timeout(mock_time, mock_logger, mock_radio):
+def test_receive_timeout(mock_time, mock_logger, mock_radio, mock_message_counter):
     """Test timeout during reception."""
-    packet_manager = PacketManager(mock_logger, mock_radio, "")
+    packet_manager = PacketManager(mock_logger, mock_radio, "", mock_message_counter)
 
     # Set up mock time to simulate timeout
     # We need at least 3 values:
@@ -267,25 +299,28 @@ def test_receive_timeout(mock_time, mock_logger, mock_radio):
     mock_logger.debug.assert_called_with("Listen timeout reached", elapsed=11.0)
 
 
-def test_get_header_and_payload(mock_logger, mock_radio):
+def test_get_header_and_payload(mock_logger, mock_radio, mock_message_counter):
     """Test _get_header and _get_payload helper methods."""
-    packet_manager = PacketManager(mock_logger, mock_radio, "")
+    packet_manager = PacketManager(mock_logger, mock_radio, "", mock_message_counter)
 
     # Create a test packet
+    packet_identifier = 1
     sequence_num = 42
     total_packets = 100
     rssi = -70
     payload = b"Test payload data"
 
     header = (
-        sequence_num.to_bytes(2, "big")
+        packet_identifier.to_bytes(1, "big")
+        + sequence_num.to_bytes(2, "big")
         + total_packets.to_bytes(2, "big")
         + abs(rssi).to_bytes(1, "big")
     )
     test_packet = header + payload
 
     # Test _get_header
-    seq, total, signal = packet_manager._get_header(test_packet)
+    p_id, seq, total, signal = packet_manager._get_header(test_packet)
+    assert p_id == packet_identifier
     assert seq == sequence_num
     assert total == total_packets
     assert signal == rssi
@@ -295,9 +330,11 @@ def test_get_header_and_payload(mock_logger, mock_radio):
     assert extracted_payload == payload
 
 
-def test_send_acknowledgement(mock_logger, mock_radio):
+def test_send_acknowledgement(mock_logger, mock_radio, mock_message_counter):
     """Test sending acknowledgment packet."""
-    packet_manager = PacketManager(mock_logger, mock_radio, "TEST")
+    packet_manager = PacketManager(
+        mock_logger, mock_radio, "TEST", mock_message_counter
+    )
 
     # Call the send_acknowledgement method
     packet_manager.send_acknowledgement()
@@ -307,3 +344,17 @@ def test_send_acknowledgement(mock_logger, mock_radio):
 
     # Verify that the acknowledgment message was logged
     mock_logger.debug.assert_called_with("Sent acknowledgment packet")
+
+
+def test_get_packet_identifier(mock_logger, mock_radio, mock_message_counter):
+    """Test _get_packet_identifier helper method."""
+    packet_manager = PacketManager(mock_logger, mock_radio, "", mock_message_counter)
+
+    # Call the _get_packet_identifier method
+    result = packet_manager._get_packet_identifier()
+
+    # Verify that the message counter was incremented
+    mock_message_counter.increment.assert_called_once()
+
+    # Verify that the result is the value from the counter
+    assert result == mock_message_counter.get()


### PR DESCRIPTION
## Summary
Adds a 1 byte number to the header of packets that identifies the message it came from. Receive will bounce any packets that don't match the identifier it's looking for. Should be a good start for adding retry logic in the future.

## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
