### PR TITLE
Refactor logger to extract counter

### DIFF
--- a/pysquared/beacon.py
+++ b/pysquared/beacon.py
@@ -24,7 +24,7 @@ except ImportError:
     from microcontroller import Processor
 
 from .hardware.radio.packetizer.packet_manager import PacketManager
-from .logger import Logger
+from .logger.logger_proto import LoggerProto
 from .nvm.counter import Counter
 from .nvm.flag import Flag
 from .protos.imu import IMUProto
@@ -43,7 +43,7 @@ class Beacon:
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         name: str,
         packet_manager: PacketManager,
         boot_time: float,
@@ -64,7 +64,7 @@ class Beacon:
             boot_time: The time the system booted.
             *args: A list of sensors and other components to include in the beacon.
         """
-        self._log: Logger = logger
+        self._log: LoggerProto = logger
         self._name: str = name
         self._packet_manager: PacketManager = packet_manager
         self._boot_time: float = boot_time

--- a/pysquared/cdh.py
+++ b/pysquared/cdh.py
@@ -24,7 +24,7 @@ import microcontroller
 
 from .config.config import Config
 from .hardware.radio.packetizer.packet_manager import PacketManager
-from .logger import Logger
+from .logger.logger_proto import LoggerProto
 
 
 class CommandDataHandler:
@@ -36,7 +36,7 @@ class CommandDataHandler:
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         config: Config,
         packet_manager: PacketManager,
         send_delay: float = 0.2,
@@ -49,7 +49,7 @@ class CommandDataHandler:
             packet_manager: The packet manager to use for sending and receiving data.
             send_delay: The delay between sending an acknowledgement and the response.
         """
-        self._log: Logger = logger
+        self._log: LoggerProto = logger
         self._config: Config = config
         self._packet_manager: PacketManager = packet_manager
         self._send_delay: float = send_delay

--- a/pysquared/hardware/burnwire/manager/burnwire.py
+++ b/pysquared/hardware/burnwire/manager/burnwire.py
@@ -17,7 +17,7 @@ import time
 
 from digitalio import DigitalInOut
 
-from ....logger import Logger
+from ....logger.logger_proto import LoggerProto
 from ....protos.burnwire import BurnwireProto
 
 
@@ -26,7 +26,7 @@ class BurnwireManager(BurnwireProto):
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         enable_burn: DigitalInOut,
         fire_burn: DigitalInOut,
         enable_logic: bool = True,
@@ -39,7 +39,7 @@ class BurnwireManager(BurnwireProto):
             fire_burn: The pin used to fire the burnwire.
             enable_logic: The logic level to enable the burnwire.
         """
-        self._log: Logger = logger
+        self._log: LoggerProto = logger
         self._enable_logic: bool = enable_logic
 
         self._enable_burn: DigitalInOut = enable_burn

--- a/pysquared/hardware/busio.py
+++ b/pysquared/hardware/busio.py
@@ -8,7 +8,7 @@ import time
 from busio import I2C, SPI
 from microcontroller import Pin
 
-from ..logger import Logger
+from ..logger.logger_proto import LoggerProto
 from .exception import HardwareInitializationError
 
 try:
@@ -18,7 +18,7 @@ except ImportError:
 
 
 def initialize_spi_bus(
-    logger: Logger,
+    logger: LoggerProto,
     clock: Pin,
     mosi: Optional[Pin] = None,
     miso: Optional[Pin] = None,
@@ -62,7 +62,7 @@ def initialize_spi_bus(
 
 
 def _spi_init(
-    logger: Logger,
+    logger: LoggerProto,
     clock: Pin,
     mosi: Optional[Pin] = None,
     miso: Optional[Pin] = None,
@@ -91,7 +91,7 @@ def _spi_init(
 
 
 def _spi_configure(
-    logger: Logger,
+    logger: LoggerProto,
     spi: SPI,
     baudrate: Optional[int],
     phase: Optional[int],
@@ -141,7 +141,7 @@ def _spi_configure(
 
 
 def initialize_i2c_bus(
-    logger: Logger,
+    logger: LoggerProto,
     scl: Pin,
     sda: Pin,
     frequency: Optional[int],

--- a/pysquared/hardware/digitalio.py
+++ b/pysquared/hardware/digitalio.py
@@ -5,12 +5,12 @@ satellite hardware. Includes retry logic for robust hardware initialization and 
 from digitalio import DigitalInOut, Direction
 from microcontroller import Pin
 
-from ..logger import Logger
+from ..logger.logger_proto import LoggerProto
 from .exception import HardwareInitializationError
 
 
 def initialize_pin(
-    logger: Logger, pin: Pin, direction: Direction, initial_value: bool
+    logger: LoggerProto, pin: Pin, direction: Direction, initial_value: bool
 ) -> DigitalInOut:
     """
     Initializes a DigitalInOut pin with the specified direction and initial value.

--- a/pysquared/hardware/imu/manager/lsm6dsox.py
+++ b/pysquared/hardware/imu/manager/lsm6dsox.py
@@ -16,7 +16,7 @@ temp_data = imu.get_temperature()
 from adafruit_lsm6ds.lsm6dsox import LSM6DSOX
 from busio import I2C
 
-from ....logger import Logger
+from ....logger.logger_proto import LoggerProto
 from ....protos.imu import IMUProto
 from ....protos.temperature_sensor import TemperatureSensorProto
 from ...exception import HardwareInitializationError
@@ -27,7 +27,7 @@ class LSM6DSOXManager(IMUProto, TemperatureSensorProto):
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         i2c: I2C,
         address: int,
     ) -> None:
@@ -41,7 +41,7 @@ class LSM6DSOXManager(IMUProto, TemperatureSensorProto):
         Raises:
             HardwareInitializationError: If the IMU fails to initialize.
         """
-        self._log: Logger = logger
+        self._log: LoggerProto = logger
 
         try:
             self._log.debug("Initializing IMU")

--- a/pysquared/hardware/magnetometer/manager/lis2mdl.py
+++ b/pysquared/hardware/magnetometer/manager/lis2mdl.py
@@ -14,7 +14,7 @@ mag_data = magnetometer.get_vector()
 from adafruit_lis2mdl import LIS2MDL
 from busio import I2C
 
-from ....logger import Logger
+from ....logger.logger_proto import LoggerProto
 from ....protos.magnetometer import MagnetometerProto
 from ...exception import HardwareInitializationError
 
@@ -24,7 +24,7 @@ class LIS2MDLManager(MagnetometerProto):
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         i2c: I2C,
     ) -> None:
         """Initializes the LIS2MDLManager.
@@ -36,7 +36,7 @@ class LIS2MDLManager(MagnetometerProto):
         Raises:
             HardwareInitializationError: If the magnetometer fails to initialize.
         """
-        self._log: Logger = logger
+        self._log: LoggerProto = logger
 
         try:
             self._log.debug("Initializing magnetometer")

--- a/pysquared/hardware/power_monitor/manager/ina219.py
+++ b/pysquared/hardware/power_monitor/manager/ina219.py
@@ -16,7 +16,7 @@ current = power_monitor.get_current()
 from adafruit_ina219 import INA219
 from busio import I2C
 
-from ....logger import Logger
+from ....logger.logger_proto import LoggerProto
 from ....protos.power_monitor import PowerMonitorProto
 from ...exception import HardwareInitializationError
 
@@ -26,7 +26,7 @@ class INA219Manager(PowerMonitorProto):
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         i2c: I2C,
         addr: int,
     ) -> None:
@@ -40,7 +40,7 @@ class INA219Manager(PowerMonitorProto):
         Raises:
             HardwareInitializationError: If the INA219 fails to initialize.
         """
-        self._log: Logger = logger
+        self._log: LoggerProto = logger
         try:
             logger.debug("Initializing INA219 power monitor")
             self._ina219: INA219 = INA219(i2c, addr)

--- a/pysquared/hardware/radio/manager/base.py
+++ b/pysquared/hardware/radio/manager/base.py
@@ -6,7 +6,7 @@ ensures that all radio managers adhere to a consistent interface.
 """
 
 from ....config.radio import RadioConfig
-from ....logger import Logger
+from ....logger.logger_proto import LoggerProto
 from ....protos.radio import RadioProto
 from ...exception import HardwareInitializationError
 from ..modulation import FSK, LoRa, RadioModulation
@@ -23,7 +23,7 @@ class BaseRadioManager(RadioProto):
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         radio_config: RadioConfig,
         **kwargs: object,
     ) -> None:

--- a/pysquared/hardware/radio/manager/rfm9x.py
+++ b/pysquared/hardware/radio/manager/rfm9x.py
@@ -27,7 +27,7 @@ except ImportError:
     from adafruit_rfm.rfm9xfsk import RFM9xFSK
 
 from ....config.radio import FSKConfig, LORAConfig, RadioConfig
-from ....logger import Logger
+from ....logger.logger_proto import LoggerProto
 from ....protos.temperature_sensor import TemperatureSensorProto
 from ..modulation import FSK, LoRa, RadioModulation
 from .base import BaseRadioManager
@@ -46,7 +46,7 @@ class RFM9xManager(BaseRadioManager, TemperatureSensorProto):
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         radio_config: RadioConfig,
         spi: SPI,
         chip_select: DigitalInOut,

--- a/pysquared/hardware/radio/manager/sx126x.py
+++ b/pysquared/hardware/radio/manager/sx126x.py
@@ -26,7 +26,7 @@ from proves_sx126._sx126x import ERR_NONE
 from proves_sx126.sx1262 import SX1262
 
 from ....config.radio import FSKConfig, LORAConfig, RadioConfig
-from ....logger import Logger
+from ....logger.logger_proto import LoggerProto
 from ..modulation import FSK, LoRa, RadioModulation
 from .base import BaseRadioManager
 
@@ -44,7 +44,7 @@ class SX126xManager(BaseRadioManager):
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         radio_config: RadioConfig,
         spi: SPI,
         chip_select: DigitalInOut,

--- a/pysquared/hardware/radio/manager/sx1280.py
+++ b/pysquared/hardware/radio/manager/sx1280.py
@@ -25,7 +25,7 @@ from proves_sx1280.sx1280 import SX1280
 
 from pysquared.config.radio import RadioConfig
 
-from ....logger import Logger
+from ....logger.logger_proto import LoggerProto
 from ..modulation import LoRa, RadioModulation
 from .base import BaseRadioManager
 
@@ -43,7 +43,7 @@ class SX1280Manager(BaseRadioManager):
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         radio_config: RadioConfig,
         spi: SPI,
         chip_select: DigitalInOut,

--- a/pysquared/hardware/radio/packetizer/packet_manager.py
+++ b/pysquared/hardware/radio/packetizer/packet_manager.py
@@ -17,7 +17,7 @@ received_data = packet_manager.listen()
 import math
 import time
 
-from ....logger import Logger
+from ....logger.logger_proto import LoggerProto
 from ....nvm.counter import Counter
 from ....protos.radio import RadioProto
 
@@ -32,7 +32,7 @@ class PacketManager:
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         radio: RadioProto,
         license: str,
         message_counter: Counter,
@@ -46,7 +46,7 @@ class PacketManager:
             license: The license key for sending data.
             send_delay: The delay between sending packets.
         """
-        self._logger: Logger = logger
+        self._logger: LoggerProto = logger
         self._radio: RadioProto = radio
         self._send_delay: float = send_delay
         self._license: str = license

--- a/pysquared/logger/__init__.py
+++ b/pysquared/logger/__init__.py
@@ -1,0 +1,1 @@
+"""Logger module for PySquared."""

--- a/pysquared/logger/log_level.py
+++ b/pysquared/logger/log_level.py
@@ -1,0 +1,14 @@
+"""Log level constants for Logger."""
+
+
+class LogLevel:
+    """
+    Defines log level constants for Logger.
+    """
+
+    NOTSET = 0
+    DEBUG = 1
+    INFO = 2
+    WARNING = 3
+    ERROR = 4
+    CRITICAL = 5

--- a/pysquared/logger/logger_proto.py
+++ b/pysquared/logger/logger_proto.py
@@ -1,0 +1,25 @@
+"""Protocol to define the logger interface."""
+
+
+class LoggerProto:
+    """Protocol defining the interface for a logger."""
+
+    def debug(self, message: str, **kwargs) -> None:
+        """Logs a message with DEBUG level."""
+        ...
+
+    def info(self, message: str, **kwargs) -> None:
+        """Logs a message with INFO level."""
+        ...
+
+    def warning(self, message: str, **kwargs) -> None:
+        """Logs a message with WARNING level."""
+        ...
+
+    def error(self, message: str, err: Exception, **kwargs) -> None:
+        """Logs a message with ERROR level, including an exception."""
+        ...
+
+    def critical(self, message: str, err: Exception, **kwargs: object) -> None:
+        """Logs a message with CRITICAL level, including an exception."""
+        ...

--- a/pysquared/logger/middleware/error_counter/error_counter.py
+++ b/pysquared/logger/middleware/error_counter/error_counter.py
@@ -8,10 +8,10 @@ Usage:
 from .nvm.counter import Counter
 from .logger.default_logger import DefaultLogger
 from .logger.middleware.error_counter.error_counter import add_logger_middleware_error_counter
-c = Counter(0)
-l = DefaultLogger()
-l = add_logger_middleware_error_counter(c)(l)
-l.critical("Test critical error", err=Exception("Test exception"))
+count = Counter(0)
+logger = DefaultLogger()
+logger = add_logger_middleware_error_counter(count)(logger)
+logger.critical("Test critical error", err=Exception("Test exception"))
 ```
 """
 

--- a/pysquared/logger/middleware/error_counter/error_counter.py
+++ b/pysquared/logger/middleware/error_counter/error_counter.py
@@ -1,0 +1,116 @@
+"""
+Error Counter Middleware for Logger
+
+This module provides a middleware for the Logger records the number of errors logged to a non-volatile memory (NVM) counter.
+
+Usage:
+```python
+from .nvm.counter import Counter
+from .logger.default_logger import DefaultLogger
+from .logger.middleware.error_counter.error_counter import add_logger_middleware_error_counter
+c = Counter(0)
+l = DefaultLogger()
+l = add_logger_middleware_error_counter(c)(l)
+l.critical("Test critical error", err=Exception("Test exception"))
+```
+"""
+
+try:
+    from typing import Callable
+except ImportError:
+    pass
+
+from ....nvm.counter import Counter
+from ...logger_proto import LoggerProto
+
+
+def add_logger_middleware_error_counter(
+    counter: Counter,
+) -> Callable[[LoggerProto], LoggerProto]:
+    """Adds error counting middleware to a logger.
+
+    Args:
+        counter (Counter): Counter for error occurrences.
+    Returns:
+        Callable[[LoggerProto], LoggerProto]: A function that takes a logger and returns a new logger with error counting middleware.
+    """
+    return lambda next_logger: ErrorCountLogger(counter, next_logger)
+
+
+class ErrorCountLogger(LoggerProto):
+    """
+    Logger that counts the number of errors logged.
+    """
+
+    def __init__(self, counter: Counter, next_logger: LoggerProto) -> None:
+        """
+        Initializes the ErrorCountLogger instance.
+
+        Args:
+            error_counter (Counter): Counter for error occurrences.
+        """
+        self._counter: Counter = counter
+        self._next_logger: LoggerProto = next_logger
+
+    def debug(self, message: str, **kwargs: object) -> None:
+        """
+        Log a message with severity level DEBUG.
+
+        Args:
+            message (str): The log message.
+            **kwargs: Additional key/value pairs to include in the log.
+        """
+        self._next_logger.debug(message, **kwargs)
+
+    def info(self, message: str, **kwargs: object) -> None:
+        """
+        Log a message with severity level INFO.
+
+        Args:
+            message (str): The log message.
+            **kwargs: Additional key/value pairs to include in the log.
+        """
+        self._next_logger.info(message, **kwargs)
+
+    def warning(self, message: str, **kwargs: object) -> None:
+        """
+        Log a message with severity level WARNING.
+
+        Args:
+            message (str): The log message.
+            **kwargs: Additional key/value pairs to include in the log.
+        """
+        self._next_logger.warning(message, **kwargs)
+
+    def error(self, message: str, err: Exception, **kwargs: object) -> None:
+        """
+        Log a message with severity level ERROR.
+
+        Args:
+            message (str): The log message.
+            err (Exception): The exception to log.
+            **kwargs: Additional key/value pairs to include in the log.
+        """
+        self._counter.increment()
+        self._next_logger.error(message, err, **kwargs)
+
+    def critical(self, message: str, err: Exception, **kwargs: object) -> None:
+        """
+        Log a message with severity level CRITICAL.
+
+        Args:
+            message (str): The log message.
+            err (Exception): The exception to log.
+            **kwargs: Additional key/value pairs to include in the log.
+        """
+        self._counter.increment()
+        self._next_logger.critical(message, err, **kwargs)
+
+    def get_error_count(self) -> int:
+        """
+        Returns the current error count.
+
+        Returns:
+            int: The number of errors logged.
+        """
+        return self._counter.get()

--- a/pysquared/power_health.py
+++ b/pysquared/power_health.py
@@ -15,7 +15,7 @@ health_status = power_health.get()
 """
 
 from .config.config import Config
-from .logger import Logger
+from .logger.logger_proto import LoggerProto
 from .protos.power_monitor import PowerMonitorProto
 
 try:
@@ -60,7 +60,7 @@ class PowerHealth:
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         config: Config,
         power_monitor: PowerMonitorProto,
     ) -> None:
@@ -71,7 +71,7 @@ class PowerHealth:
             config: The configuration to use.
             power_monitor: The power monitor to use.
         """
-        self.logger: Logger = logger
+        self.logger: LoggerProto = logger
         self.config: Config = config
         self._power_monitor: PowerMonitorProto = power_monitor
 

--- a/pysquared/rtc/manager/rv3028.py
+++ b/pysquared/rtc/manager/rv3028.py
@@ -17,7 +17,7 @@ from busio import I2C
 from rv3028.rv3028 import RV3028
 
 from ...hardware.exception import HardwareInitializationError
-from ...logger import Logger
+from ...logger.logger_proto import LoggerProto
 from ...protos.rtc import RTCProto
 
 
@@ -26,7 +26,7 @@ class RV3028Manager(RTCProto):
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerProto,
         i2c: I2C,
     ) -> None:
         """Initializes the RV3028Manager.
@@ -38,7 +38,7 @@ class RV3028Manager(RTCProto):
         Raises:
             HardwareInitializationError: If the RTC fails to initialize.
         """
-        self._log: Logger = logger
+        self._log: LoggerProto = logger
 
         try:
             self._log.debug("Initializing RTC")

--- a/pysquared/sleep_helper.py
+++ b/pysquared/sleep_helper.py
@@ -10,7 +10,7 @@ import alarm
 from alarm.time import TimeAlarm
 
 from .config.config import Config
-from .logger import Logger
+from .logger.logger_proto import LoggerProto
 from .watchdog import Watchdog
 
 
@@ -25,7 +25,7 @@ class SleepHelper:
         config (Config): Configuration object.
     """
 
-    def __init__(self, logger: Logger, config: Config, watchdog: Watchdog) -> None:
+    def __init__(self, logger: LoggerProto, config: Config, watchdog: Watchdog) -> None:
         """
         Creates a SleepHelper object.
 
@@ -34,7 +34,7 @@ class SleepHelper:
             watchdog (Watchdog): Watchdog instance for system safety.
             config (Config): Configuration object.
         """
-        self.logger: Logger = logger
+        self.logger: LoggerProto = logger
         self.config: Config = config
         self.watchdog: Watchdog = watchdog
 

--- a/pysquared/watchdog.py
+++ b/pysquared/watchdog.py
@@ -9,7 +9,7 @@ from digitalio import DigitalInOut, Direction
 from microcontroller import Pin
 
 from .hardware.digitalio import initialize_pin
-from .logger import Logger
+from .logger.logger_proto import LoggerProto
 
 
 class Watchdog:
@@ -21,7 +21,7 @@ class Watchdog:
         _digital_in_out (DigitalInOut): Digital output for controlling the watchdog pin.
     """
 
-    def __init__(self, logger: Logger, pin: Pin) -> None:
+    def __init__(self, logger: LoggerProto, pin: Pin) -> None:
         """
         Initializes the Watchdog timer.
 

--- a/tests/unit/hardware/imu/manager/test_lsm6dsox_manager.py
+++ b/tests/unit/hardware/imu/manager/test_lsm6dsox_manager.py
@@ -15,7 +15,7 @@ from busio import I2C
 from mocks.adafruit_lsm6ds.lsm6dsox import LSM6DSOX
 from pysquared.hardware.exception import HardwareInitializationError
 from pysquared.hardware.imu.manager.lsm6dsox import LSM6DSOXManager
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 
 address: int = 123
 
@@ -29,7 +29,7 @@ def mock_i2c() -> MagicMock:
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Fixture for mock Logger."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/hardware/radio/manager/test_rfm9x_manager.py
+++ b/tests/unit/hardware/radio/manager/test_rfm9x_manager.py
@@ -20,7 +20,7 @@ from pysquared.config.radio import RadioConfig
 from pysquared.hardware.exception import HardwareInitializationError
 from pysquared.hardware.radio.manager.rfm9x import RFM9xManager
 from pysquared.hardware.radio.modulation import FSK, LoRa
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 
 
 @pytest.fixture
@@ -44,7 +44,7 @@ def mock_reset() -> MagicMock:
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/hardware/radio/manager/test_sx126x_manager.py
+++ b/tests/unit/hardware/radio/manager/test_sx126x_manager.py
@@ -18,7 +18,7 @@ from pysquared.config.radio import RadioConfig
 from pysquared.hardware.exception import HardwareInitializationError
 from pysquared.hardware.radio.manager.sx126x import SX126xManager
 from pysquared.hardware.radio.modulation import FSK, LoRa
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 
 
 @pytest.fixture
@@ -54,7 +54,7 @@ def mock_gpio() -> MagicMock:
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/hardware/radio/manager/test_sx1280_manager.py
+++ b/tests/unit/hardware/radio/manager/test_sx1280_manager.py
@@ -18,7 +18,7 @@ from pysquared.config.radio import RadioConfig
 from pysquared.hardware.exception import HardwareInitializationError
 from pysquared.hardware.radio.manager.sx1280 import SX1280Manager
 from pysquared.hardware.radio.modulation import LoRa
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 
 
 @pytest.fixture
@@ -60,7 +60,7 @@ def mock_rxen() -> MagicMock:
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/hardware/radio/packetizer/test_packet_manager.py
+++ b/tests/unit/hardware/radio/packetizer/test_packet_manager.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pysquared.hardware.radio.packetizer.packet_manager import PacketManager
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 from pysquared.nvm.counter import Counter
 from pysquared.protos.radio import RadioProto
 
@@ -20,7 +20,7 @@ from pysquared.protos.radio import RadioProto
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/hardware/test_burnwire.py
+++ b/tests/unit/hardware/test_burnwire.py
@@ -11,13 +11,13 @@ import pytest
 from digitalio import DigitalInOut
 
 from pysquared.hardware.burnwire.manager.burnwire import BurnwireManager
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 
 
 @pytest.fixture
 def mock_logger():
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/hardware/test_busio.py
+++ b/tests/unit/hardware/test_busio.py
@@ -13,7 +13,7 @@ from microcontroller import Pin
 
 from pysquared.hardware.busio import initialize_i2c_bus, initialize_spi_bus
 from pysquared.hardware.exception import HardwareInitializationError
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 
 
 @patch("pysquared.hardware.busio.SPI")
@@ -24,7 +24,7 @@ def test_initialize_spi_bus_success(mock_spi: MagicMock):
         mock_spi: Mocked SPI class.
     """
     # Mock the logger
-    mock_logger = MagicMock(spec=Logger)
+    mock_logger = MagicMock(spec=LoggerProto)
 
     # Mock pins
     mock_clock = MagicMock(spec=Pin)
@@ -64,7 +64,7 @@ def test_initialize_spi_bus_failure(mock_spi: MagicMock):
         mock_spi: Mocked SPI class.
     """
     # Mock the logger
-    mock_logger = MagicMock(spec=Logger)
+    mock_logger = MagicMock(spec=LoggerProto)
 
     # Mock pins
     mock_clock = MagicMock(spec=Pin)
@@ -91,7 +91,7 @@ def test_spi_bus_configure_try_lock_failure(mock_spi: MagicMock):
         mock_spi: Mocked SPI class.
     """
     # Mock the logger
-    mock_logger = MagicMock(spec=Logger)
+    mock_logger = MagicMock(spec=LoggerProto)
 
     # Mock pins
     mock_clock = MagicMock(spec=Pin)
@@ -121,7 +121,7 @@ def test_spi_bus_configure_failure(mock_spi: MagicMock):
         mock_spi: Mocked SPI class.
     """
     # Mock the logger
-    mock_logger = MagicMock(spec=Logger)
+    mock_logger = MagicMock(spec=LoggerProto)
 
     # Mock pins
     mock_clock = MagicMock(spec=Pin)
@@ -152,7 +152,7 @@ def test_initialize_i2c_bus_success(mock_i2c: MagicMock):
         mock_i2c: Mocked I2C class.
     """
     # Mock the logger
-    mock_logger = MagicMock(spec=Logger)
+    mock_logger = MagicMock(spec=LoggerProto)
 
     # Mock pins
     mock_scl = MagicMock(spec=Pin)
@@ -181,7 +181,7 @@ def test_initialize_i2c_bus_failure(mock_i2c: MagicMock):
         mock_i2c: Mocked I2C class.
     """
     # Mock the logger
-    mock_logger = MagicMock(spec=Logger)
+    mock_logger = MagicMock(spec=LoggerProto)
 
     # Mock pins
     mock_scl = MagicMock(spec=Pin)

--- a/tests/unit/hardware/test_digitalio.py
+++ b/tests/unit/hardware/test_digitalio.py
@@ -12,7 +12,7 @@ from digitalio import Direction
 
 from pysquared.hardware.digitalio import initialize_pin
 from pysquared.hardware.exception import HardwareInitializationError
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 
 
 @patch("pysquared.hardware.digitalio.DigitalInOut")
@@ -25,7 +25,7 @@ def test_initialize_pin_success(mock_pin: MagicMock, mock_digital_in_out: MagicM
         mock_digital_in_out: Mocked DigitalInOut class.
     """
     # Mock the logger
-    mock_logger = MagicMock(spec=Logger)
+    mock_logger = MagicMock(spec=LoggerProto)
 
     # Mock pin and direction
     mock_pin = mock_pin()
@@ -55,7 +55,7 @@ def test_initialize_pin_failure(mock_pin: MagicMock, mock_digital_in_out: MagicM
         mock_digital_in_out: Mocked DigitalInOut class.
     """
     # Mock the logger
-    mock_logger = MagicMock(spec=Logger)
+    mock_logger = MagicMock(spec=LoggerProto)
 
     # Mock pin and direction
     mock_pin = mock_pin()

--- a/tests/unit/logger/middleware/test_error_counter.py
+++ b/tests/unit/logger/middleware/test_error_counter.py
@@ -1,0 +1,134 @@
+"""Unit tests for the Logger class.
+
+This module contains unit tests for the `Logger` class, which provides logging
+functionality with different severity levels, colorized output, and error counting.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import pysquared.nvm.counter as counter
+from pysquared.logger.default_logger import DefaultLogger
+from pysquared.logger.middleware.error_counter.error_counter import (
+    add_logger_middleware_error_counter,
+)
+
+
+@pytest.fixture
+def logger():
+    """Provides a Logger instance for testing without colorization."""
+    count = MagicMock(spec=counter.Counter)
+    logger = DefaultLogger(count)
+    return add_logger_middleware_error_counter(count)(logger)
+
+
+def test_debug_log(capsys, logger):
+    """Tests logging a debug message without colorization.
+
+    Args:
+        capsys: Pytest fixture to capture stdout/stderr.
+        logger: Logger instance for testing.
+    """
+    logger.debug("This is a debug message", blake="jameson")
+    captured = capsys.readouterr()
+    assert "DEBUG" in captured.out
+    assert "This is a debug message" in captured.out
+    assert '"blake": "jameson"' in captured.out
+
+    logger._counter.increment.assert_not_called()
+
+
+def test_info_log(capsys, logger):
+    """Tests logging an info message without colorization.
+
+    Args:
+        capsys: Pytest fixture to capture stdout/stderr.
+        logger: Logger instance for testing.
+    """
+    logger.info(
+        "This is a info message!!",
+        foo="bar",
+    )
+    captured = capsys.readouterr()
+    assert "INFO" in captured.out
+    assert "This is a info message!!" in captured.out
+    assert '"foo": "bar"' in captured.out
+
+    logger._counter.increment.assert_not_called()
+
+
+def test_warning_log(capsys, logger):
+    """Tests logging a warning message without colorization.
+
+    Args:
+        capsys: Pytest fixture to capture stdout/stderr.
+        logger: Logger instance for testing.
+    """
+    logger.warning(
+        "This is a warning message!!??!",
+        boo="bar",
+        pleiades="maia",
+        cube="sat",
+        err=Exception("manual exception"),
+    )
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.out
+    assert "This is a warning message!!??!" in captured.out
+    assert '"boo": "bar"' in captured.out
+    assert '"pleiades": "maia"' in captured.out
+    assert '"cube": "sat"' in captured.out
+    assert "Exception: manual exception" in captured.out
+
+    logger._counter.increment.assert_not_called()
+
+
+def test_error_log(capsys, logger):
+    """Tests logging an error message without colorization.
+
+    Args:
+        capsys: Pytest fixture to capture stdout/stderr.
+        logger: Logger instance for testing.
+    """
+    logger.error(
+        "This is an error message",
+        OSError("Manually creating an OS Error for testing"),
+        pleiades="five",
+        please="work",
+    )
+    captured = capsys.readouterr()
+    assert "ERROR" in captured.out
+    assert "This is an error message" in captured.out
+    assert '"pleiades": "five"' in captured.out
+    assert '"please": "work"' in captured.out
+    assert "OSError: Manually creating an OS Error for testing" in captured.out
+
+    logger._counter.increment.assert_called_once()
+
+
+def test_critical_log(capsys, logger):
+    """Tests logging a critical message without colorization.
+
+    Args:
+        capsys: Pytest fixture to capture stdout/stderr.
+        logger: Logger instance for testing.
+    """
+    logger.critical(
+        "THIS IS VERY CRITICAL",
+        OSError("Manually creating an OS Error"),
+        ad="astra",
+        space="lab",
+        soft="ware",
+        j="20",
+        config="king",
+    )
+    captured = capsys.readouterr()
+    assert "CRITICAL" in captured.out
+    assert "THIS IS VERY CRITICAL" in captured.out
+    assert '"ad": "astra"' in captured.out
+    assert '"space": "lab"' in captured.out
+    assert '"soft": "ware"' in captured.out
+    assert '"j": "20"' in captured.out
+    assert '"config": "king"' in captured.out
+
+    logger._counter.increment.assert_called_once()

--- a/tests/unit/logger/test_logger.py
+++ b/tests/unit/logger/test_logger.py
@@ -1,7 +1,7 @@
 """Unit tests for the Logger class.
 
 This module contains unit tests for the `Logger` class, which provides logging
-functionality with different severity levels, colorized output, and error counting.
+functionality with different severity levels, and colorized output.
 """
 
 from unittest.mock import MagicMock
@@ -9,22 +9,19 @@ from unittest.mock import MagicMock
 import pytest
 from microcontroller import Pin
 
-import pysquared.nvm.counter as counter
-from pysquared.logger import Logger, _color
+from pysquared.logger.default_logger import DefaultLogger
 
 
 @pytest.fixture
 def logger():
     """Provides a Logger instance for testing without colorization."""
-    count = MagicMock(spec=counter.Counter)
-    return Logger(count)
+    return DefaultLogger()
 
 
 @pytest.fixture
 def logger_color():
     """Provides a Logger instance for testing with colorization enabled."""
-    count = MagicMock(spec=counter.Counter)
-    return Logger(error_counter=count, colorized=True)
+    return DefaultLogger(colorized=True)
 
 
 def test_debug_log(capsys, logger):
@@ -172,7 +169,7 @@ def test_debug_log_color(capsys, logger_color):
     """
     logger_color.debug("This is a debug message", blake="jameson")
     captured = capsys.readouterr()
-    assert _color(msg="DEBUG", color="blue") in captured.out
+    assert DefaultLogger._color(msg="DEBUG", color="blue") in captured.out
     assert "This is a debug message" in captured.out
     assert '"blake": "jameson"' in captured.out
 
@@ -186,7 +183,7 @@ def test_info_log_color(capsys, logger_color):
     """
     logger_color.info("This is a info message!!", foo="bar")
     captured = capsys.readouterr()
-    assert _color(msg="INFO", color="green") in captured.out
+    assert DefaultLogger._color(msg="INFO", color="green") in captured.out
     assert "This is a info message!!" in captured.out
     assert '"foo": "bar"' in captured.out
 
@@ -202,7 +199,7 @@ def test_warning_log_color(capsys, logger_color):
         "This is a warning message!!??!", boo="bar", pleiades="maia", cube="sat"
     )
     captured = capsys.readouterr()
-    assert _color(msg="WARNING", color="orange") in captured.out
+    assert DefaultLogger._color(msg="WARNING", color="orange") in captured.out
     assert "This is a warning message!!??!" in captured.out
     assert '"boo": "bar"' in captured.out
     assert '"pleiades": "maia"' in captured.out
@@ -223,7 +220,7 @@ def test_error_log_color(capsys, logger_color):
         err=OSError("Manually creating an OS Error"),
     )
     captured = capsys.readouterr()
-    assert _color(msg="ERROR", color="pink") in captured.out
+    assert DefaultLogger._color(msg="ERROR", color="pink") in captured.out
     assert "This is an error message" in captured.out
     assert '"pleiades": "five"' in captured.out
     assert '"please": "work"' in captured.out
@@ -246,7 +243,7 @@ def test_critical_log_color(capsys, logger_color):
         err=OSError("Manually creating an OS Error"),
     )
     captured = capsys.readouterr()
-    assert _color(msg="CRITICAL", color="red") in captured.out
+    assert DefaultLogger._color(msg="CRITICAL", color="red") in captured.out
     assert "THIS IS VERY CRITICAL" in captured.out
     assert '"ad": "astra"' in captured.out
     assert '"space": "lab"' in captured.out

--- a/tests/unit/rtc/manager/test_rv3028_manager.py
+++ b/tests/unit/rtc/manager/test_rv3028_manager.py
@@ -13,7 +13,7 @@ from busio import I2C
 
 from mocks.rv3028 import RV3028
 from pysquared.hardware.exception import HardwareInitializationError
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 from pysquared.rtc.manager.rv3028 import RV3028Manager
 
 
@@ -26,7 +26,7 @@ def mock_i2c() -> MagicMock:
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Fixture for mock Logger."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/test_beacon.py
+++ b/tests/unit/test_beacon.py
@@ -18,7 +18,7 @@ from mocks.circuitpython.microcontroller import Processor
 from pysquared.beacon import Beacon
 from pysquared.hardware.radio.modulation import LoRa, RadioModulation
 from pysquared.hardware.radio.packetizer.packet_manager import PacketManager
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 from pysquared.nvm.counter import Counter
 from pysquared.nvm.flag import Flag
 from pysquared.protos.imu import IMUProto
@@ -30,7 +30,7 @@ from pysquared.protos.temperature_sensor import TemperatureSensorProto
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/test_cdh.py
+++ b/tests/unit/test_cdh.py
@@ -13,13 +13,13 @@ import pytest
 from pysquared.cdh import CommandDataHandler
 from pysquared.config.config import Config
 from pysquared.hardware.radio.packetizer.packet_manager import PacketManager
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 
 
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/test_power_health.py
+++ b/tests/unit/test_power_health.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from pysquared.config.config import Config
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 from pysquared.power_health import CRITICAL, DEGRADED, NOMINAL, UNKNOWN, PowerHealth
 from pysquared.protos.power_monitor import PowerMonitorProto
 
@@ -19,7 +19,7 @@ from pysquared.protos.power_monitor import PowerMonitorProto
 @pytest.fixture
 def mock_logger():
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/test_sleep_helper.py
+++ b/tests/unit/test_sleep_helper.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pysquared.config.config import Config
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 from pysquared.watchdog import Watchdog
 
 # Create mock modules for alarm and alarm.time before importing SleepHelper
@@ -28,7 +28,7 @@ from pysquared.sleep_helper import SleepHelper  # noqa: E402
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @pytest.fixture

--- a/tests/unit/test_watchdog.py
+++ b/tests/unit/test_watchdog.py
@@ -10,7 +10,7 @@ import pytest
 from digitalio import DigitalInOut, Direction
 from microcontroller import Pin
 
-from pysquared.logger import Logger
+from pysquared.logger.logger_proto import LoggerProto
 from pysquared.watchdog import Watchdog
 
 
@@ -23,7 +23,7 @@ def mock_pin() -> MagicMock:
 @pytest.fixture
 def mock_logger() -> MagicMock:
     """Mocks the Logger class."""
-    return MagicMock(spec=Logger)
+    return MagicMock(spec=LoggerProto)
 
 
 @patch("pysquared.watchdog.initialize_pin")


### PR DESCRIPTION
## Summary
This PR adds a middleware pattern to the logger, allowing its functionality to be extended.

Our logger has always felt like a terrific generic logging platform that doesn't exist yet in the CircuitPython community. The only issue is when we add in features that are specific to this repo like our Counter. This PR extracts the counter into a middleware which can be optionally included wherever it is wanted. Eventually this pattern could evolve further with middlewares for colorizing, writing logs to files, etc.

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
