### PR TITLE
Introduce MCP9809 Temperature Sensor Manager

### DIFF
--- a/mocks/adafruit_mcp9808/__init__.py
+++ b/mocks/adafruit_mcp9808/__init__.py
@@ -1,0 +1,10 @@
+"""Mock for the Adafruit MCP9808 temperature sensor.
+
+This module provides a mock implementation of the Adafruit MCP9808 temperature sensor for
+testing purposes. It allows for simulating the behavior of the MCP9808 without the
+need for actual hardware.
+"""
+
+from .mcp9808 import MCP9808
+
+__all__ = ["MCP9808"]

--- a/mocks/adafruit_mcp9808/mcp9808.py
+++ b/mocks/adafruit_mcp9808/mcp9808.py
@@ -1,0 +1,22 @@
+"""Mock for the Adafruit MCP9808 temperature sensor.
+
+This module provides a mock implementation of the Adafruit MCP9808 temperature sensor for
+testing purposes. It allows for simulating the behavior of the MCP9808 without the
+need for actual hardware.
+"""
+
+
+class MCP9808:
+    """A mock MCP9808 temperature sensor."""
+
+    def __init__(self, i2c, addr) -> None:
+        """Initializes the mock MCP9808.
+
+        Args:
+            i2c: The I2C bus to use.
+            addr: The I2C address of the MCP9808.
+        """
+        self.i2c = i2c
+        self.addr = addr
+
+    temperature = 25.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ packages = [
     "pysquared.hardware.radio.packetizer",
     "pysquared.hardware.power_monitor",
     "pysquared.hardware.power_monitor.manager",
+    "pysquared.hardware.temperature_sensor",
+    "pysquared.hardware.temperature_sensor.manager",
     "pysquared.hardware.burnwire",
     "pysquared.hardware.burnwire.manager",
     "pysquared.nvm",

--- a/pysquared/hardware/__init__.py
+++ b/pysquared/hardware/__init__.py
@@ -1,3 +1,7 @@
 """
 This module provides managers for various hardware components including sensors, actuators, communication interfaces, etc.
 """
+
+from . import temperature_sensor
+
+__all__ = ["temperature_sensor"]

--- a/pysquared/hardware/temperature_sensor/__init__.py
+++ b/pysquared/hardware/temperature_sensor/__init__.py
@@ -1,0 +1,5 @@
+"""This module provides temperature sensor hardware managers."""
+
+from .manager import MCP9808Manager
+
+__all__ = ["MCP9808Manager"]

--- a/pysquared/hardware/temperature_sensor/manager/__init__.py
+++ b/pysquared/hardware/temperature_sensor/manager/__init__.py
@@ -1,0 +1,5 @@
+"""This module provides temperature sensor manager implementations."""
+
+from .mcp9808 import MCP9808Manager
+
+__all__ = ["MCP9808Manager"]

--- a/pysquared/hardware/temperature_sensor/manager/mcp9808.py
+++ b/pysquared/hardware/temperature_sensor/manager/mcp9808.py
@@ -1,0 +1,60 @@
+"""This module defines the `MCP9808Manager` class, which provides a high-level interface
+for interacting with the MCP9808 temperature sensor. It handles the initialization of the sensor
+and provides methods for reading temperature data.
+
+**Usage:**
+```python
+logger = Logger()
+i2c = busio.I2C(board.SCL, board.SDA)
+temp_sensor = MCP9808Manager(logger, i2c, 0x18)
+temperature = temp_sensor.get_temperature()
+```
+"""
+
+from adafruit_mcp9808 import MCP9808
+from busio import I2C
+
+from ....logger import Logger
+from ....protos.temperature_sensor import TemperatureSensorProto
+from ...exception import HardwareInitializationError
+
+
+class MCP9808Manager(TemperatureSensorProto):
+    """Manages the MCP9808 temperature sensor."""
+
+    def __init__(
+        self,
+        logger: Logger,
+        i2c: I2C,
+        addr: int = 0x18,
+    ) -> None:
+        """Initializes the MCP9808Manager.
+
+        Args:
+            logger: The logger to use.
+            i2c: The I2C bus connected to the chip.
+            addr: The I2C address of the MCP9808. Defaults to 0x18.
+
+        Raises:
+            HardwareInitializationError: If the MCP9808 fails to initialize.
+        """
+        self._log: Logger = logger
+        try:
+            logger.debug("Initializing MCP9808 temperature sensor")
+            self._mcp9808: MCP9808 = MCP9808(i2c, addr)
+        except Exception as e:
+            raise HardwareInitializationError(
+                "Failed to initialize MCP9808 temperature sensor"
+            ) from e
+
+    def get_temperature(self) -> float | None:
+        """Gets the temperature reading from the MCP9808.
+
+        Returns:
+            The temperature in degrees Celsius, or None if the data is not available.
+        """
+        try:
+            return self._mcp9808.temperature
+        except Exception as e:
+            self._log.error("Error retrieving MCP9808 temperature sensor values", e)
+            return None

--- a/pysquared/hardware/temperature_sensor/manager/mcp9808.py
+++ b/pysquared/hardware/temperature_sensor/manager/mcp9808.py
@@ -14,6 +14,11 @@ temperature = temp_sensor.get_temperature()
 from adafruit_mcp9808 import MCP9808
 from busio import I2C
 
+try:
+    from typing_extensions import Literal
+except ImportError:
+    pass
+
 from ....logger import Logger
 from ....protos.temperature_sensor import TemperatureSensorProto
 from ...exception import HardwareInitializationError
@@ -27,6 +32,7 @@ class MCP9808Manager(TemperatureSensorProto):
         logger: Logger,
         i2c: I2C,
         addr: int = 0x18,
+        resolution: Literal[0, 1, 2, 3] = 1,
     ) -> None:
         """Initializes the MCP9808Manager.
 
@@ -34,6 +40,15 @@ class MCP9808Manager(TemperatureSensorProto):
             logger: The logger to use.
             i2c: The I2C bus connected to the chip.
             addr: The I2C address of the MCP9808. Defaults to 0x18.
+            resolution: The resolution of the temperature sensor. Defaults to 1 which is 0.25 degrees celsius.
+            =======   ============   ==============
+            Value     Resolution     Reading Time
+            =======   ============   ==============
+            0          0.5°C            30 ms
+            1          0.25°C           65 ms
+            2         0.125°C          130 ms
+            3         0.0625°C         250 ms
+            =======   ============   ==============
 
         Raises:
             HardwareInitializationError: If the MCP9808 fails to initialize.
@@ -46,6 +61,8 @@ class MCP9808Manager(TemperatureSensorProto):
             raise HardwareInitializationError(
                 "Failed to initialize MCP9808 temperature sensor"
             ) from e
+
+        self._mcp9808.resolution = resolution
 
     def get_temperature(self) -> float | None:
         """Gets the temperature reading from the MCP9808.

--- a/tests/unit/hardware/temperature_sensor/__init__.py
+++ b/tests/unit/hardware/temperature_sensor/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for temperature sensor hardware managers."""

--- a/tests/unit/hardware/temperature_sensor/manager/__init__.py
+++ b/tests/unit/hardware/temperature_sensor/manager/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for temperature sensor manager implementations."""

--- a/tests/unit/hardware/temperature_sensor/manager/test_mcp9808_manager.py
+++ b/tests/unit/hardware/temperature_sensor/manager/test_mcp9808_manager.py
@@ -1,0 +1,260 @@
+"""Tests for the MCP9808Manager class."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mocks.adafruit_mcp9808.mcp9808 import MCP9808
+from pysquared.hardware.exception import HardwareInitializationError
+from pysquared.hardware.temperature_sensor.manager.mcp9808 import MCP9808Manager
+from pysquared.logger import Logger
+
+
+@pytest.fixture
+def mock_logger():
+    """Creates a mock logger for testing.
+
+    Returns:
+        MagicMock: A mock logger instance.
+    """
+    return MagicMock(spec=Logger)
+
+
+@pytest.fixture
+def mock_i2c():
+    """Creates a mock I2C bus for testing.
+
+    Returns:
+        MagicMock: A mock I2C bus instance.
+    """
+    return MagicMock()
+
+
+class MockMCP9808WithError(MCP9808):
+    """Mock MCP9808 that raises an exception when temperature is accessed."""
+
+    def __init__(self, i2c, addr, error_to_raise):
+        """Initialize the mock with I2C bus and address."""
+        super().__init__(i2c, addr)
+        self._error_to_raise = error_to_raise
+
+    @property
+    def temperature(self):
+        """Raise the specified exception when accessed."""
+        raise self._error_to_raise
+
+
+class MockMCP9808WithTemperature(MCP9808):
+    """Mock MCP9808 with configurable temperature value."""
+
+    def __init__(self, i2c, addr, temperature_value):
+        """Initialize the mock with I2C bus, address and temperature value."""
+        super().__init__(i2c, addr)
+        self._temperature_value = temperature_value
+
+    @property
+    def temperature(self):
+        """Return the configured temperature value."""
+        return self._temperature_value
+
+
+class TestMCP9808Manager:
+    """Test cases for the MCP9808Manager class."""
+
+    def test_init_success(
+        self,
+        mock_logger: MagicMock,
+        mock_i2c: MagicMock,
+    ):
+        """Tests successful initialization of MCP9808Manager.
+
+        Args:
+            mock_logger: Mocked Logger instance.
+            mock_i2c: Mocked I2C bus.
+        """
+        with patch(
+            "pysquared.hardware.temperature_sensor.manager.mcp9808.MCP9808"
+        ) as mock_mcp9808_class:
+            mock_mcp9808_instance = MCP9808(mock_i2c, 0x18)
+            mock_mcp9808_class.return_value = mock_mcp9808_instance
+
+            manager = MCP9808Manager(mock_logger, mock_i2c, 0x18)
+
+            assert manager._log == mock_logger
+            assert manager._mcp9808 == mock_mcp9808_instance
+            mock_logger.debug.assert_called_once_with(
+                "Initializing MCP9808 temperature sensor"
+            )
+            mock_mcp9808_class.assert_called_once_with(mock_i2c, 0x18)
+
+    def test_init_default_address(
+        self,
+        mock_logger: MagicMock,
+        mock_i2c: MagicMock,
+    ):
+        """Tests initialization with default I2C address.
+
+        Args:
+            mock_logger: Mocked Logger instance.
+            mock_i2c: Mocked I2C bus.
+        """
+        with patch(
+            "pysquared.hardware.temperature_sensor.manager.mcp9808.MCP9808"
+        ) as mock_mcp9808_class:
+            mock_mcp9808_instance = MCP9808(mock_i2c, 0x18)
+            mock_mcp9808_class.return_value = mock_mcp9808_instance
+
+            _ = MCP9808Manager(mock_logger, mock_i2c)
+
+            mock_mcp9808_class.assert_called_once_with(mock_i2c, 0x18)
+
+    def test_init_failure(
+        self,
+        mock_logger: MagicMock,
+        mock_i2c: MagicMock,
+    ):
+        """Tests initialization failure handling.
+
+        Args:
+            mock_logger: Mocked Logger instance.
+            mock_i2c: Mocked I2C bus.
+        """
+        with patch(
+            "pysquared.hardware.temperature_sensor.manager.mcp9808.MCP9808"
+        ) as mock_mcp9808_class:
+            init_error = RuntimeError("I2C communication failed")
+            mock_mcp9808_class.side_effect = init_error
+
+            with pytest.raises(HardwareInitializationError) as exc_info:
+                MCP9808Manager(mock_logger, mock_i2c, 0x18)
+
+            assert "Failed to initialize MCP9808 temperature sensor" in str(
+                exc_info.value
+            )
+            assert exc_info.value.__cause__ == init_error
+
+    def test_get_temperature_success(
+        self,
+        mock_logger: MagicMock,
+        mock_i2c: MagicMock,
+    ):
+        """Tests successful temperature reading.
+
+        Args:
+            mock_logger: Mocked Logger instance.
+            mock_i2c: Mocked I2C bus.
+        """
+        expected_temperature = 25.5
+
+        with patch(
+            "pysquared.hardware.temperature_sensor.manager.mcp9808.MCP9808"
+        ) as mock_mcp9808_class:
+            mock_mcp9808_instance = MCP9808(mock_i2c, 0x18)
+            mock_mcp9808_instance.temperature = expected_temperature
+            mock_mcp9808_class.return_value = mock_mcp9808_instance
+
+            manager = MCP9808Manager(mock_logger, mock_i2c, 0x18)
+            temperature = manager.get_temperature()
+
+        assert temperature == expected_temperature
+
+    def test_get_temperature_exception(
+        self,
+        mock_logger: MagicMock,
+        mock_i2c: MagicMock,
+    ):
+        """Tests temperature reading exception handling.
+
+        Args:
+            mock_logger: Mocked Logger instance.
+            mock_i2c: Mocked I2C bus.
+        """
+        read_error = RuntimeError("Sensor read failed")
+
+        with patch(
+            "pysquared.hardware.temperature_sensor.manager.mcp9808.MCP9808"
+        ) as mock_mcp9808_class:
+            mock_mcp9808_instance = MockMCP9808WithError(mock_i2c, 0x18, read_error)
+            mock_mcp9808_class.return_value = mock_mcp9808_instance
+
+            manager = MCP9808Manager(mock_logger, mock_i2c, 0x18)
+            temperature = manager.get_temperature()
+
+        assert temperature is None
+        mock_logger.error.assert_called_once_with(
+            "Error retrieving MCP9808 temperature sensor values", read_error
+        )
+
+    def test_get_temperature_none_value(
+        self,
+        mock_logger: MagicMock,
+        mock_i2c: MagicMock,
+    ):
+        """Tests temperature reading when sensor returns None.
+
+        Args:
+            mock_logger: Mocked Logger instance.
+            mock_i2c: Mocked I2C bus.
+        """
+        with patch(
+            "pysquared.hardware.temperature_sensor.manager.mcp9808.MCP9808"
+        ) as mock_mcp9808_class:
+            mock_mcp9808_instance = MockMCP9808WithTemperature(mock_i2c, 0x18, None)
+            mock_mcp9808_class.return_value = mock_mcp9808_instance
+
+            manager = MCP9808Manager(mock_logger, mock_i2c, 0x18)
+            temperature = manager.get_temperature()
+
+        assert temperature is None
+
+    def test_get_temperature_negative_value(
+        self,
+        mock_logger: MagicMock,
+        mock_i2c: MagicMock,
+    ):
+        """Tests temperature reading with negative temperature value.
+
+        Args:
+            mock_logger: Mocked Logger instance.
+            mock_i2c: Mocked I2C bus.
+        """
+        expected_temperature = -10.5
+
+        with patch(
+            "pysquared.hardware.temperature_sensor.manager.mcp9808.MCP9808"
+        ) as mock_mcp9808_class:
+            mock_mcp9808_instance = MockMCP9808WithTemperature(
+                mock_i2c, 0x18, expected_temperature
+            )
+            mock_mcp9808_class.return_value = mock_mcp9808_instance
+
+            manager = MCP9808Manager(mock_logger, mock_i2c, 0x18)
+            temperature = manager.get_temperature()
+
+        assert temperature == expected_temperature
+
+    def test_get_temperature_high_value(
+        self,
+        mock_logger: MagicMock,
+        mock_i2c: MagicMock,
+    ):
+        """Tests temperature reading with high temperature value.
+
+        Args:
+            mock_logger: Mocked Logger instance.
+            mock_i2c: Mocked I2C bus.
+        """
+        expected_temperature = 85.0
+
+        with patch(
+            "pysquared.hardware.temperature_sensor.manager.mcp9808.MCP9808"
+        ) as mock_mcp9808_class:
+            mock_mcp9808_instance = MockMCP9808WithTemperature(
+                mock_i2c, 0x18, expected_temperature
+            )
+            mock_mcp9808_class.return_value = mock_mcp9808_instance
+
+            manager = MCP9808Manager(mock_logger, mock_i2c, 0x18)
+            temperature = manager.get_temperature()
+
+        assert temperature == expected_temperature


### PR DESCRIPTION
## Summary
This PR adds support for the MCP9808 temperature sensor by implementing a CircuitPython manager that adheres to the TemperatureSensorProto interface. The implementation includes comprehensive unit tests, proper error handling, and follows the established patterns in the codebase.

## How was this tested
- [X] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)

## Usage Example
```py
from pysquared.hardware.temperature_sensor.manager.mcp9808 import MCP9808Manager
from pysquared.logger import Logger
import busio

logger = Logger()
i2c = busio.I2C(board.SCL, board.SDA)
temp_sensor = MCP9808Manager(logger, i2c, addr=0x18, resolution=1)
temperature = temp_sensor.get_temperature()  # Returns float in Celsius or None
```

## Technical Details
MCP9808Manager Features
Resolution Control: Supports 4 resolution levels with corresponding reading times:
- 0: 0.5°C (30ms)
- 1: 0.25°C (65ms) - default
- 2: 0.125°C (130ms)
- 3: 0.0625°C (250ms)

Error Handling: Graceful handling of sensor communication failures
Type Safety: Full type annotations with proper forward references
Logging: Integrated debug and error logging

## Testing Strategy
- Mock Classes: Two specialized mock classes for different test scenarios:
- MockMCP9808WithError: Raises exceptions when temperature is accessed
- MockMCP9808WithTemperature: Returns configurable temperature values
- Comprehensive Coverage: Tests all code paths including error conditions
- Pattern Consistency: Follows the same testing patterns as other sensor managers
