### PR TITLE
Force interpreter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "sonarlint.connectedMode.project": {
         "connectionId": "proves-kit",
         "projectKey": "proveskit_circuitpy_flight_software"
-    }
+    },
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }


### PR DESCRIPTION
## Summary
This PR forces vscode to use the python version installed by UV. The dev container reaaaally wants to use its own built-in interpreter. We may want to base the dev container on something that does not have python installed by default.

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
